### PR TITLE
feat: Add Sigpy backend

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install CPU Backends
         shell: bash
         run: |
-          python -m pip install finufft pynfft2 "cython<3.0.0"
+          python -m pip install finufft pynfft2 "cython<3.0.0" sigpy
 
       - name: Run Tests
         shell: bash

--- a/src/mrinufft/operators/interfaces/sigpy.py
+++ b/src/mrinufft/operators/interfaces/sigpy.py
@@ -76,4 +76,5 @@ class MRISigpyNUFFT(FourierOperatorCPU):
 
     @property
     def norm_factor(self):
+        """Normalization factor of the operator."""
         return np.sqrt(2 ** len(self.shape))

--- a/src/mrinufft/operators/interfaces/sigpy.py
+++ b/src/mrinufft/operators/interfaces/sigpy.py
@@ -17,7 +17,7 @@ except ImportError:
 class RawSigpyNUFFT:
     """Raw interface to SigPy NUFFT."""
 
-    def __init__(self, samples, shape, oversamp=1.25, width=4):
+    def __init__(self, samples, shape, oversamp=1.25, width=4, **kwargs):
         shape = np.array(shape)
         # scale in FOV/2 units
         self.samples = samples * shape

--- a/src/mrinufft/operators/interfaces/sigpy.py
+++ b/src/mrinufft/operators/interfaces/sigpy.py
@@ -28,13 +28,24 @@ class RawSigpyNUFFT:
 
     def op(self, coeffs_data, grid_data):
         """Forward Operator."""
-        ret = sgf.nufft(grid_data, self.samples, self._oversamp, self._width)
+        ret = sgf.nufft(
+            grid_data,
+            self.samples,
+            oversamp=self._oversamp,
+            width=self._width,
+        )
         np.copyto(coeffs_data, ret)
         return coeffs_data
 
     def adj_op(self, coeffs_data, grid_data):
         """Adjoint Operator."""
-        ret = sgf.nufft_adjoint(coeffs_data, self.samples, self._oversamp, self._width)
+        ret = sgf.nufft_adjoint(
+            coeffs_data,
+            self.samples,
+            oshape=self.shape,
+            oversamp=self._oversamp,
+            width=self._width,
+        )
         np.copyto(grid_data, ret)
         return grid_data
 
@@ -55,13 +66,14 @@ class MRISigpyNUFFT(FourierOperatorCPU):
         density=False,
         n_coils=1,
         smaps=None,
-        squeeze_dims=True,
         **kwargs,
     ):
         samples_ = proper_trajectory(samples, normalize="unit")
 
-        super().__init__(
-            samples_, shape, density, n_coils, smaps=smaps, squeeze_dims=squeeze_dims
-        )
+        super().__init__(samples_, shape, density, n_coils, smaps=smaps)
 
         self.raw_op = RawSigpyNUFFT(samples_, shape, **kwargs)
+
+    @property
+    def norm_factor(self):
+        return np.sqrt(2 ** len(self.shape))

--- a/src/mrinufft/operators/interfaces/sigpy.py
+++ b/src/mrinufft/operators/interfaces/sigpy.py
@@ -1,0 +1,67 @@
+"""Sigpy NUFFT interface.
+
+The SigPy NUFFT is fully implemented in Python.
+"""
+
+import numpy as np
+from ..base import FourierOperatorCPU, proper_trajectory
+
+
+SIGPY_AVAILABLE = True
+try:
+    import sigpy.fourier as sgf
+except ImportError:
+    SIGPY_AVAILABLE = False
+
+
+class RawSigpyNUFFT:
+    """Raw interface to SigPy NUFFT."""
+
+    def __init__(self, samples, shape, oversamp=1.25, width=4):
+        shape = np.array(shape)
+        # scale in FOV/2 units
+        self.samples = samples * shape
+
+        self.shape = shape
+        self._oversamp = oversamp
+        self._width = width
+
+    def op(self, coeffs_data, grid_data):
+        """Forward Operator."""
+        ret = sgf.nufft(grid_data, self.samples, self._oversamp, self._width)
+        np.copyto(coeffs_data, ret)
+        return coeffs_data
+
+    def adj_op(self, coeffs_data, grid_data):
+        """Adjoint Operator."""
+        ret = sgf.nufft_adjoint(coeffs_data, self.samples, self._oversamp, self._width)
+        np.copyto(grid_data, ret)
+        return grid_data
+
+
+class MRISigpyNUFFT(FourierOperatorCPU):
+    """NUFFT using SigPy.
+
+    This is a wrapper around the SigPy NUFFT operator.
+    """
+
+    backend = "sigpy"
+    available = SIGPY_AVAILABLE
+
+    def __init__(
+        self,
+        samples,
+        shape,
+        density=False,
+        n_coils=1,
+        smaps=None,
+        squeeze_dims=True,
+        **kwargs,
+    ):
+        samples_ = proper_trajectory(samples, normalize="unit")
+
+        super().__init__(
+            samples_, shape, density, n_coils, smaps=smaps, squeeze_dims=squeeze_dims
+        )
+
+        self.raw_op = RawSigpyNUFFT(samples_, shape, **kwargs)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -24,6 +24,7 @@ from helpers import kspace_from_op, image_from_op
         "finufft",
         "cufinufft",
         "gpunufft",
+        "sigpy",
     ],
 )
 @parametrize_with_cases("kspace_locs, shape", cases=CasesTrajectories)
@@ -40,7 +41,7 @@ def operator(
 
 @fixture(scope="session", autouse=True)
 def ref_backend(request):
-    """get the reference backend from the CLI"""
+    """Get the reference backend from the CLI."""
     return request.config.getoption("ref")
 
 

--- a/tests/test_stacked.py
+++ b/tests/test_stacked.py
@@ -27,12 +27,10 @@ def operator(request, backend, kspace_locs, shape, z_index, n_batchs, n_coils, s
 
     if z_index == "full":
         z_index = np.arange(shape3d[-1])
-        z_index_ = z_index
     elif z_index == "random_mask":
-        z_index = np.random.rand(shape3d[-1]) > 0.5
-        z_index_ = np.arange(shape3d[-1])[z_index]
+        z_index = np.random.choice(shape3d[-1], shape3d[-1] // 2, replace=False)
 
-    kspace_locs3d = stacked2traj3d(kspace_locs, z_index_, shape[-1])
+    kspace_locs3d = stacked2traj3d(kspace_locs, z_index, shape[-1])
     # smaps support
     if sense:
         smaps = 1j * np.random.rand(n_coils, *shape3d)


### PR DESCRIPTION
This PR add SigPy as a backend. 

Here the nufft is entirely implemented in Python. Sigpy support GPU computation  but here only the numpy/CPU one is implemented. 

This was surprisingly very easy to do. 