### PR TITLE
Cufinufft torch

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -174,6 +174,7 @@ jobs:
 
           source $RUNNER_WORKSPACE/venv/bin/activate
           python setup.py install
+          pip install cupy-cuda11x
 
       - name: Run Tests
         shell: bash

--- a/examples/example_density.py
+++ b/examples/example_density.py
@@ -1,0 +1,148 @@
+# %%
+"""
+=============================
+Density Compensation Routines
+=============================
+
+Examples of differents density compensation methods.
+
+Density compensation depends on the sampling trajectory,and is apply before the
+adjoint operation to act as preconditioner, and should make the lipschitz constant
+of the operator roughly equal to 1.
+
+"""
+import brainweb_dl as bwdl
+
+import matplotlib.pyplot as plt
+import numpy as np
+from mrinufft import get_density, get_operator
+from mrinufft.trajectories import initialize_2D_radial
+from mrinufft.trajectories.display import display_2D_trajectory
+
+
+# %%
+# Create sample data
+# ------------------
+
+mri_2D = bwdl.get_mri(4, "T1")[80, ...]
+
+print(mri_2D.shape)
+
+traj = initialize_2D_radial(192, 192)
+
+nufft = get_operator("finufft")(traj, mri_2D.shape, density=False)
+kspace = nufft.op(mri_2D)
+adjoint = nufft.adj_op(kspace)
+
+fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+axs[0].imshow(abs(mri_2D))
+display_2D_trajectory(traj, subfigure=axs[1])
+axs[2].imshow(abs(adjoint))
+
+# %%
+# As you can see, the radial sampling pattern as a strong concentration of sampling point in the center, resulting in a  low-frequency biased adjoint reconstruction.
+
+# %%
+# Geometry based methods
+# ======================
+#
+# Voronoi
+# -------
+#
+# Voronoi Parcellation attribute a weights to each k-space coordinate, inversely
+# proportional to its voronoi cell area.
+
+
+# .. warning::
+#    The current implementation of voronoi parcellation is CPU only, and is thus
+#    **very** slow in 3D ( > 1h).
+
+# %%
+voronoi_weights = get_density("voronoi", traj)
+
+nufft_voronoi = get_operator("finufft")(traj, shape=mri_2D.shape, density=voronoi_weights)
+adjoint_voronoi = nufft_voronoi.adj_op(kspace)
+fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+axs[0].imshow(abs(mri_2D))
+axs[0].set_title("Ground Truth")
+axs[1].imshow(abs(adjoint))
+axs[1].set_title("no density compensation")
+axs[2].imshow(abs(adjoint_voronoi))
+axs[2].set_title("Voronoi density compensation")
+
+
+# %%
+# Cell Counting
+# -------------
+#
+# Cell Counting attributes weights based on the number of trajectory point lying in a same k-space nyquist voxel.
+# This can be viewed as an approximation to the voronoi neth
+
+# .. note::
+#    Cell counting is faster than voronoi (especially in 3D), but is less precise. 
+
+# The size of the niquist voxel can be tweak by using the osf parameter. Typically as the NUFFT (and by default in MRI-NUFFT) is performed at an OSF of 2 
+
+
+# %%
+cell_count_weights = get_density("cell_count", traj, shape=mri_2D.shape, osf=2.0)
+
+nufft_cell_count = get_operator("finufft")(traj, shape=mri_2D.shape, density=cell_count_weights, upsampfac=2.0)
+adjoint_cell_count = nufft_cell_count.adj_op(kspace)
+fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+axs[0].imshow(abs(mri_2D))
+axs[0].set_title("Ground Truth")
+axs[1].imshow(abs(adjoint))
+axs[1].set_title("no density compensation")
+axs[2].imshow(abs(adjoint_cell_count))
+axs[2].set_title("cell_count density compensation")
+
+# %%
+# Manual Density Estimation
+# -------------------------
+# 
+# For some analytical trajectory it is also possible to determine the density compensation vector directly.
+# In radial trajectory for instance, a sample's weight can be determined from its distance to the center.
+
+
+# %%
+flat_traj = traj.reshape(-1, 2)
+weights = np.sqrt(np.sum(flat_traj ** 2, axis=1))
+nufft = get_operator("finufft")(traj, shape=mri_2D.shape, density=weights)
+adjoint_manual = nufft.adj_op(kspace)
+fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+axs[0].imshow(abs(mri_2D))
+axs[0].set_title("Ground Truth")
+axs[1].imshow(abs(adjoint))
+axs[1].set_title("no density compensation")
+axs[2].imshow(abs(adjoint_manual))
+axs[2].set_title("manual density compensation")
+
+# %%
+# Operator-based method
+# =====================
+#
+# Pipe's Method
+# -------------
+# Pipe's method is an iterative scheme, that use the interpolation and spreading kernel operator for computing the density compensation. 
+# 
+# .. warning:: 
+#    If this method is widely used in the literature, there exists no convergence guarantees for it. 
+
+# .. note:: 
+#    The Pipe method is currently only implemented for gpuNUFFT. 
+
+# %%
+if check_backend("gpunufft"):
+    flat_traj = traj.reshape(-1, 2)
+    nufft = get_operator("gpunufft")(traj, shape=mri_2D.shape, density="pipe")
+    adjoint_manual = nufft.adj_op(kspace)
+    fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+    axs[0].imshow(abs(mri_2D))
+    axs[0].set_title("Ground Truth")
+    axs[1].imshow(abs(adjoint))
+    axs[1].set_title("no density compensation")
+    axs[2].imshow(abs(adjoint_manual))
+    axs[2].set_title("manual density compensation")
+
+# %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ ignore = [
 "B905", #zip() without an explicit strict= parameter
 "B028", #No explicit stacklevel keyword argument found
 ]
-extend-exclude = [ "example_*.py" ]
+extend-exclude = [ "example_*.py" , "*_version.py"]
 [tool.ruff.pydocstyle]
 convention="numpy"
 

--- a/src/mrinufft/__init__.py
+++ b/src/mrinufft/__init__.py
@@ -35,7 +35,7 @@ from .trajectories import (
     display_3D_trajectory,
 )
 
-from .density import voronoi, cell_count, pipe
+from .density import voronoi, cell_count, pipe, get_density
 
 __all__ = [
     "get_operator",
@@ -65,6 +65,7 @@ __all__ = [
     "voronoi",
     "cell_count",
     "pipe",
+    "get_density",
 ]
 
 

--- a/src/mrinufft/_utils.py
+++ b/src/mrinufft/_utils.py
@@ -25,21 +25,20 @@ try:
     ARRAY_LIBS["torch"] = (torch, torch.Tensor)
 except ImportError:
     pass
-
+    NP2TORCH = {}
+else:
+    NP2TORCH = {
+        np.dtype("float64"): torch.float64,
+        np.dtype("float32"): torch.float32,
+        np.dtype("complex64"): torch.complex64,
+        np.dtype("complex128"): torch.complex128,
+    }
 try:
     from tensorflow.experimental import numpy as tnp
 
     ARRAY_LIBS["tensorflow"] = (tnp, tnp.ndarray)
 except ImportError:
     pass
-
-
-NP2TORCH = {
-    np.dtype("float64"): torch.float64,
-    np.dtype("float32"): torch.float32,
-    np.dtype("complex64"): torch.complex64,
-    np.dtype("complex128"): torch.complex128,
-}
 
 
 def get_array_module(array):

--- a/src/mrinufft/_utils.py
+++ b/src/mrinufft/_utils.py
@@ -1,0 +1,82 @@
+"""General utility functions for MRI-NUFFT."""
+
+import warnings
+from collections import defaultdict
+from functools import wraps
+import numpy as np
+
+
+def proper_trajectory(trajectory, normalize="pi"):
+    """Normalize the trajectory to be used by NUFFT operators.
+
+    Parameters
+    ----------
+    trajectory: np.ndarray
+        The trajectory to normalize, it might be of shape (Nc, Ns, dim) of (Ns, dim)
+
+    normalize: str
+        if "pi" trajectory will be rescaled in [-pi, pi], if it was in [-0.5, 0.5]
+        if "unit" trajectory will be rescaled in [-0.5, 0.5] if it was not [-0.5, 0.5]
+
+    Returns
+    -------
+    new_traj: np.ndarray
+        The normalized trajectory of shape (Nc * Ns, dim) or (Ns, dim) in -pi, pi
+    """
+    # flatten to a list of point
+    try:
+        new_traj = np.asarray(trajectory).copy()
+    except Exception as e:
+        raise ValueError(
+            "trajectory should be array_like, with the last dimension being coordinates"
+        ) from e
+    new_traj = new_traj.reshape(-1, trajectory.shape[-1])
+
+    if normalize == "pi" and np.max(abs(new_traj)) - 1e-4 < 0.5:
+        warnings.warn(
+            "Samples will be rescaled to [-pi, pi), assuming they were in [-0.5, 0.5)"
+        )
+        new_traj *= 2 * np.pi
+    elif normalize == "unit" and np.max(abs(new_traj)) - 1e-4 > 0.5:
+        warnings.warn(
+            "Samples will be rescaled to [-0.5, 0.5), assuming they were in [-pi, pi)"
+        )
+        new_traj /= 2 * np.pi
+    if normalize == "unit" and np.max(new_traj) >= 0.5:
+        new_traj = (new_traj + 0.5) % 1 - 0.5
+    return new_traj
+
+
+class MethodRegister:
+    """
+    A Decorator to register methods of the same type in dictionnaries.
+
+    Parameters
+    ----------
+    name: str
+        The  register
+    """
+
+    registry = defaultdict(dict)
+
+    def __init__(self, register_name):
+        self.register_name = register_name
+
+    def __call__(self, method_name=None):
+        """Register the function in the registry."""
+
+        def decorator(func):
+            self.registry[self.register_name][method_name] = func
+
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        if callable(method_name):
+            func = method_name
+            method_name = func.__name__
+            return decorator(func)
+        else:
+            return decorator

--- a/src/mrinufft/density/__init__.py
+++ b/src/mrinufft/density/__init__.py
@@ -1,6 +1,13 @@
 """Density compensation methods."""
 from .geometry_based import voronoi, voronoi_unique, cell_count
 from .nufft_based import pipe
+from .utils import get_density
 
 
-__all__ = ["voronoi", "voronoi_unique", "pipe", "cell_count"]
+__all__ = [
+    "voronoi",
+    "voronoi_unique",
+    "pipe",
+    "cell_count",
+    "get_density",
+]

--- a/src/mrinufft/density/geometry_based.py
+++ b/src/mrinufft/density/geometry_based.py
@@ -2,7 +2,7 @@
 import numpy as np
 from scipy.spatial import Voronoi
 
-from .utils import flat_traj, normalize_weights
+from .utils import flat_traj, normalize_weights, register_density
 
 
 def _vol3d(points):
@@ -47,6 +47,7 @@ def _vol2d(points):
 
 
 @flat_traj
+@register_density
 def voronoi_unique(traj, *args, **kwargs):
     """Estimate  density compensation weight using voronoi parcellation.
 
@@ -87,6 +88,7 @@ def voronoi_unique(traj, *args, **kwargs):
 
 
 @flat_traj
+@register_density
 def voronoi(traj, *args, **kwargs):
     """Estimate  density compensation weight using voronoi parcellation.
 
@@ -120,6 +122,7 @@ def voronoi(traj, *args, **kwargs):
 
 
 @flat_traj
+@register_density
 def cell_count(traj, shape, osf=1.0):
     """
     Compute the number of points in each cell of the grid.

--- a/src/mrinufft/density/geometry_based.py
+++ b/src/mrinufft/density/geometry_based.py
@@ -46,8 +46,8 @@ def _vol2d(points):
     return abs(area) / 2.0
 
 
-@flat_traj
 @register_density
+@flat_traj
 def voronoi_unique(traj, *args, **kwargs):
     """Estimate  density compensation weight using voronoi parcellation.
 
@@ -87,8 +87,8 @@ def voronoi_unique(traj, *args, **kwargs):
     return wi
 
 
-@flat_traj
 @register_density
+@flat_traj
 def voronoi(traj, *args, **kwargs):
     """Estimate  density compensation weight using voronoi parcellation.
 
@@ -118,11 +118,11 @@ def voronoi(traj, *args, **kwargs):
         wi[i0] = wi[i0f] / np.sum(i0)
     else:
         wi = voronoi_unique(traj)
-    return normalize_weights(wi)
+    return 1 / normalize_weights(wi)
 
 
-@flat_traj
 @register_density
+@flat_traj
 def cell_count(traj, shape, osf=1.0):
     """
     Compute the number of points in each cell of the grid.

--- a/src/mrinufft/density/nufft_based.py
+++ b/src/mrinufft/density/nufft_based.py
@@ -1,9 +1,10 @@
 """Density compensation weights using the NUFFT-based methods."""
 
-from .utils import flat_traj
+from .utils import flat_traj, register_density
 
 
 @flat_traj
+@register_density
 def pipe(traj, shape, backend="cufinufft", **kwargs):
     """Compute the density compensation weights using the pipe method.
 

--- a/src/mrinufft/density/nufft_based.py
+++ b/src/mrinufft/density/nufft_based.py
@@ -3,8 +3,8 @@
 from .utils import flat_traj, register_density
 
 
-@flat_traj
 @register_density
+@flat_traj
 def pipe(traj, shape, backend="cufinufft", **kwargs):
     """Compute the density compensation weights using the pipe method.
 
@@ -16,6 +16,8 @@ def pipe(traj, shape, backend="cufinufft", **kwargs):
         array of shape (2,) or (3,) containing the size of the grid.
     backend: str
         backend to use for the computation. Either "cufinufft" or "tensorflow".
+    **kwargs:
+        Extra argument for the NUFFT operator.
     """
     # here to avoid circular import
     from mrinufft.operators.base import get_operator

--- a/src/mrinufft/density/nufft_based.py
+++ b/src/mrinufft/density/nufft_based.py
@@ -1,6 +1,5 @@
 """Density compensation weights using the NUFFT-based methods."""
 
-from mrinufft import get_operator
 from .utils import flat_traj
 
 
@@ -17,6 +16,9 @@ def pipe(traj, shape, backend="cufinufft", **kwargs):
     backend: str
         backend to use for the computation. Either "cufinufft" or "tensorflow".
     """
+    # here to avoid circular import
+    from mrinufft.operators.base import get_operator
+
     nufft_class = get_operator(backend)
     if hasattr(nufft_class, "pipe"):
         return nufft_class.pipe(traj, shape, **kwargs)

--- a/src/mrinufft/density/utils.py
+++ b/src/mrinufft/density/utils.py
@@ -20,6 +20,7 @@ def get_density(name, *args, **kwargs):
 
     if args or kwargs:
         return method(*args, **kwargs)
+    return method
 
 
 def flat_traj(normalize="unit"):

--- a/src/mrinufft/density/utils.py
+++ b/src/mrinufft/density/utils.py
@@ -3,7 +3,23 @@ from functools import wraps
 
 import numpy as np
 
-from mrinufft.operators import proper_trajectory
+from mrinufft._utils import MethodRegister, proper_trajectory
+
+register_density = MethodRegister("density_compensation")
+
+
+def get_density(name, *args, **kwargs):
+    """Get the density compensation function from its name."""
+    try:
+        method = register_density.registry["density_compensation"][name]
+    except KeyError as e:
+        raise ValueError(
+            f"Unknown density compensation method {name}. Available methods are \n"
+            f"{list(register_density.registry['density_compensation'].keys())}"
+        ) from e
+
+    if args or kwargs:
+        return method(*args, **kwargs)
 
 
 def flat_traj(normalize="unit"):

--- a/src/mrinufft/io/__init__.py
+++ b/src/mrinufft/io/__init__.py
@@ -1,0 +1,13 @@
+"""Input/Output module for trajectories and data."""
+
+
+from .cfl import traj2cfl, cfl2traj
+from .nsp import read_trajectory, write_trajectory
+
+
+__all__ = [
+    "traj2cfl",
+    "cfl2traj",
+    "read_trajectory",
+    "write_trajectory",
+]

--- a/src/mrinufft/io/cfl.py
+++ b/src/mrinufft/io/cfl.py
@@ -1,0 +1,139 @@
+"""utility functions for Complex-Float data file.
+
+This allow compatibility with BART toolbox and others.
+
+References
+----------
+BART Toolbox: https://bart-doc.readthedocs.io/en/latest/data.html
+"""
+from pathlib import Path
+import os
+import mmap
+import warnings
+import numpy as np
+
+
+def _readcfl(cfl_file, hdr_file=None):
+    """Read a pair of .cfl/.hdr file to get a complex numpy array.
+
+    Adapted from the BART python cfl library.
+
+    Parameters
+    ----------
+    name : str
+        Name of the file to read.
+
+    Returns
+    -------
+    array : array_like
+        Complex array read from the file.
+    """
+    basename = Path(cfl_file).with_suffix("")
+    if hdr_file is None:
+        hdr_file = basename.with_suffix(".hdr")
+    cfl_file = basename.with_suffix(".cfl")
+
+    # get dims from .hdr
+    with open(hdr_file) as h:
+        h.readline()  # skip
+        line = h.readline()
+    dims = [int(i) for i in line.split()]
+
+    # remove singleton dimensions from the end
+    n = np.prod(dims)
+    dims_prod = np.cumprod(dims)
+    dims = dims[: np.searchsorted(dims_prod, n) + 1]
+
+    # load data and reshape into dims
+    with open(cfl_file, "rb") as d:
+        a = np.fromfile(d, dtype=np.complex64, count=n)
+    return a.reshape(dims, order="F")
+
+
+def _writecfl(array, cfl_file, hdr_file=None):
+    """Write a pair of .cfl/.hdr file representing a complex array.
+
+    Adapted from the BART python cfl library.
+
+    Parameters
+    ----------
+    name : str
+        Name of the file to write.
+    array : array_like
+        Array to write to file.
+
+    """
+    basename = Path(cfl_file).with_suffix("")
+    if hdr_file is None:
+        hdr_file = basename.with_suffix(".hdr")
+    cfl_file = basename.with_suffix(".cfl")
+
+    with open(hdr_file, "w") as h:
+        h.write("# Dimensions\n")
+        for i in array.shape:
+            h.write("%d " % i)
+        h.write("\n")
+
+    size = np.prod(array.shape) * np.dtype(np.complex64).itemsize
+
+    with open(cfl_file, "w+b") as d:
+        os.ftruncate(d.fileno(), size)
+        mm = mmap.mmap(d.fileno(), size, flags=mmap.MAP_SHARED, prot=mmap.PROT_WRITE)
+        if array.dtype != np.complex64:
+            array = array.astype(np.complex64)
+        mm.write(np.ascontiguousarray(array.T))
+        mm.close()
+
+
+def traj2cfl(traj, shape, basename):
+    """
+    Export a trajectory defined in MRI-nufft to a BART compatible format.
+
+    Parameters
+    ----------
+    traj: array_like
+        trajectory array, shape (N_shot, N_points, 2 or 3)
+    shape: tuple
+        volume shape (FOV)
+
+    The trajectory will be normalized to -(FOV-1)/2 +(FOV-1)/2,
+    and reshape to BART format.
+    """
+    traj_ = traj * (np.array(shape) - 1)
+    if traj.shape[-1] == 2:
+        traj_3d = np.zeros(traj_.shape[:-1] + (3,), dtype=traj_.dtype)
+        traj_3d[..., :2] = traj_
+        traj_ = traj_3d
+    else:
+        traj_ = traj_.astype(np.complex64)
+    traj_ = traj_[None, None, ...]
+
+    _writecfl(traj_.T, basename)
+
+
+def cfl2traj(basename, shape=None):
+    """Convert a trajectory BART file to a numpy array compatible with MRI-nufft.
+
+    Parameters
+    ----------
+    filename: str
+        Base filename for the trajectory
+    shape: optional
+        Shape of the Image domain.
+    """
+    traj_raw = _readcfl(basename)
+    # Convert to float array and take only the real part
+    traj = np.ascontiguousarray(traj_raw.T.view("(2,)float32")[..., 0])
+    if np.all(traj[..., -1] == 0):
+        warnings.warn("2D Trajectory Detected")
+        traj = traj[..., :-1]
+    if shape is None:
+        maxs = [np.max(traj[..., i]) for i in range(traj.shape[-1])]
+        mins = [np.min(traj[..., i]) for i in range(traj.shape[-1])]
+        shape = np.array(maxs) - np.array(mins)
+        warnings.warn(f"Estimated shape {shape}")
+    else:
+        shape = np.asarray(shape) - 1
+
+    traj /= np.asarray(shape)
+    return np.squeeze(traj)

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -1,4 +1,5 @@
-"""Basic codes for IO for trajectories."""
+"""Read/Write trajectoru for Neurospin sequences."""
+
 import warnings
 import os
 from typing import Tuple, Optional
@@ -6,7 +7,7 @@ import numpy as np
 from datetime import datetime
 from array import array
 
-from .utils import (
+from mrinufft.trajectories.utils import (
     KMAX,
     DEFAULT_RASTER_TIME,
     DEFAULT_GMAX,

--- a/src/mrinufft/operators/__init__.py
+++ b/src/mrinufft/operators/__init__.py
@@ -5,7 +5,6 @@ import pkgutil
 from pathlib import Path
 
 from .base import (
-    proper_trajectory,
     FourierOperatorBase,
     get_operator,
     list_backends,
@@ -29,5 +28,4 @@ __all__ = [
     "check_backend",
     "get_operator",
     "list_backends",
-    "proper_trajectory",
 ]

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -152,15 +152,17 @@ class FourierOperatorBase(ABC):
 
         return MRIFourierCorrected(self, B, C, indices)
 
-    def compute_density(self, method=None, **kwargs):
+    def compute_density(self, method=None):
         """Compute the density compensation weights and set it.
 
         Parameters
         ----------
-        method: str or callable or array
+        method: str or callable or array or dict
             The method to use to compute the density compensation.
             If a string, the method should be registered in the density registry.
             If a callable, it should take the samples and the shape as input.
+            If a dict, it should have a key 'name', to determine which method to use.
+            other items will be used as kwargs.
             If an array, it should be of shape (Nsamples,) and will be used as is.
         """
         if isinstance(method, np.ndarray):
@@ -170,10 +172,10 @@ class FourierOperatorBase(ABC):
             self.density = None
             return None
 
-        if method == "pipe" and "backend" not in kwargs:
-            method = self.pipe  # will raise error if not defined.
-        if method == "pipe" and "backend" in kwargs:
-            warnings.warn(f"Using pipe with {kwargs['backend']}")
+        kwargs = {}
+        if isinstance(method, dict):
+            method = method["name"]  # should be a string !
+            kwargs = method.copy().remove("name")
         if isinstance(method, str):
             method = get_density(method)
         if not callable(method):

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -176,6 +176,8 @@ class FourierOperatorBase(ABC):
         if isinstance(method, dict):
             method = method["name"]  # should be a string !
             kwargs = method.copy().remove("name")
+        if method == "pipe" and "backend" not in kwargs:
+            kwargs["backend"] = self.backend
         if isinstance(method, str):
             method = get_density(method)
         if not callable(method):

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -14,47 +14,6 @@ import numpy as np
 DTYPE_R2C = {"float32": "complex64", "float64": "complex128"}
 
 
-def proper_trajectory(trajectory, normalize="pi"):
-    """Normalize the trajectory to be used by NUFFT operators.
-
-    Parameters
-    ----------
-    trajectory: np.ndarray
-        The trajectory to normalize, it might be of shape (Nc, Ns, dim) of (Ns, dim)
-
-    normalize: str
-        if "pi" trajectory will be rescaled in [-pi, pi], if it was in [-0.5, 0.5]
-        if "unit" trajectory will be rescaled in [-0.5, 0.5] if it was not [-0.5, 0.5]
-
-    Returns
-    -------
-    new_traj: np.ndarray
-        The normalized trajectory of shape (Nc * Ns, dim) or (Ns, dim) in -pi, pi
-    """
-    # flatten to a list of point
-    try:
-        new_traj = np.asarray(trajectory).copy()
-    except Exception as e:
-        raise ValueError(
-            "trajectory should be array_like, with the last dimension being coordinates"
-        ) from e
-    new_traj = new_traj.reshape(-1, trajectory.shape[-1])
-
-    if normalize == "pi" and np.max(abs(new_traj)) - 1e-4 < 0.5:
-        warnings.warn(
-            "Samples will be rescaled to [-pi, pi), assuming they were in [-0.5, 0.5)"
-        )
-        new_traj *= 2 * np.pi
-    elif normalize == "unit" and np.max(abs(new_traj)) - 1e-4 > 0.5:
-        warnings.warn(
-            "Samples will be rescaled to [-0.5, 0.5), assuming they were in [-pi, pi)"
-        )
-        new_traj /= 2 * np.pi
-    if normalize == "unit" and np.max(new_traj) >= 0.5:
-        new_traj = (new_traj + 0.5) % 1 - 0.5
-    return new_traj
-
-
 def check_backend(backend_name: str):
     """Check if a specific backend is available."""
     try:

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -167,6 +167,7 @@ class FourierOperatorBase(ABC):
             self.density = method
             return None
         if not method:
+            self.density = None
             return None
 
         if method == "pipe" and "backend" not in kwargs:

--- a/src/mrinufft/operators/interfaces/bart.py
+++ b/src/mrinufft/operators/interfaces/bart.py
@@ -6,13 +6,14 @@ The file format is described here: https://bart-doc.readthedocs.io/en/latest/dat
 
 """
 
-import warnings
 import os
-import numpy as np
-import mmap
 import subprocess as subp
 import tempfile
 from pathlib import Path
+
+import numpy as np
+
+from mrinufft.io.cfl import _readcfl, _writecfl, traj2cfl
 
 from ..base import FourierOperatorCPU, proper_trajectory
 
@@ -157,129 +158,3 @@ class MRIBartNUFFT(FourierOperatorCPU):
         """Normalization factor of the operator."""
         # return 1.0
         return np.sqrt(2 ** len(self.shape))
-
-
-def _readcfl(cfl_file, hdr_file=None):
-    """Read a pair of .cfl/.hdr file to get a complex numpy array.
-
-    Adapted from the BART python cfl library.
-
-    Parameters
-    ----------
-    name : str
-        Name of the file to read.
-
-    Returns
-    -------
-    array : array_like
-        Complex array read from the file.
-    """
-    basename = Path(cfl_file).with_suffix("")
-    if hdr_file is None:
-        hdr_file = basename.with_suffix(".hdr")
-    cfl_file = basename.with_suffix(".cfl")
-
-    # get dims from .hdr
-    with open(hdr_file) as h:
-        h.readline()  # skip
-        line = h.readline()
-    dims = [int(i) for i in line.split()]
-
-    # remove singleton dimensions from the end
-    n = np.prod(dims)
-    dims_prod = np.cumprod(dims)
-    dims = dims[: np.searchsorted(dims_prod, n) + 1]
-
-    # load data and reshape into dims
-    with open(cfl_file, "rb") as d:
-        a = np.fromfile(d, dtype=np.complex64, count=n)
-    return a.reshape(dims, order="F")
-
-
-def _writecfl(array, cfl_file, hdr_file=None):
-    """Write a pair of .cfl/.hdr file representing a complex array.
-
-    Adapted from the BART python cfl library.
-
-    Parameters
-    ----------
-    name : str
-        Name of the file to write.
-    array : array_like
-        Array to write to file.
-
-    """
-    basename = Path(cfl_file).with_suffix("")
-    if hdr_file is None:
-        hdr_file = basename.with_suffix(".hdr")
-    cfl_file = basename.with_suffix(".cfl")
-
-    with open(hdr_file, "w") as h:
-        h.write("# Dimensions\n")
-        for i in array.shape:
-            h.write("%d " % i)
-        h.write("\n")
-
-    size = np.prod(array.shape) * np.dtype(np.complex64).itemsize
-
-    with open(cfl_file, "w+b") as d:
-        os.ftruncate(d.fileno(), size)
-        mm = mmap.mmap(d.fileno(), size, flags=mmap.MAP_SHARED, prot=mmap.PROT_WRITE)
-        if array.dtype != np.complex64:
-            array = array.astype(np.complex64)
-        mm.write(np.ascontiguousarray(array.T))
-        mm.close()
-
-
-def traj2cfl(traj, shape, basename):
-    """
-    Export a trajectory defined in MRI-nufft to a BART compatible format.
-
-    Parameters
-    ----------
-    traj: array_like
-        trajectory array, shape (N_shot, N_points, 2 or 3)
-    shape: tuple
-        volume shape (FOV)
-
-    The trajectory will be normalized to -(FOV-1)/2 +(FOV-1)/2,
-    and reshape to BART format.
-    """
-    traj_ = traj * (np.array(shape) - 1)
-    if traj.shape[-1] == 2:
-        traj_3d = np.zeros(traj_.shape[:-1] + (3,), dtype=traj_.dtype)
-        traj_3d[..., :2] = traj_
-        traj_ = traj_3d
-    else:
-        traj_ = traj_.astype(np.complex64)
-    traj_ = traj_[None, None, ...]
-
-    _writecfl(traj_.T, basename)
-
-
-def cfl2traj(basename, shape=None):
-    """Convert a trajectory BART file to a numpy array compatible with MRI-nufft.
-
-    Parameters
-    ----------
-    filename: str
-        Base filename for the trajectory
-    shape: optional
-        Shape of the Image domain.
-    """
-    traj_raw = _readcfl(basename)
-    # Convert to float array and take only the real part
-    traj = np.ascontiguousarray(traj_raw.T.view("(2,)float32")[..., 0])
-    if np.all(traj[..., -1] == 0):
-        warnings.warn("2D Trajectory Detected")
-        traj = traj[..., :-1]
-    if shape is None:
-        maxs = [np.max(traj[..., i]) for i in range(traj.shape[-1])]
-        mins = [np.min(traj[..., i]) for i in range(traj.shape[-1])]
-        shape = np.array(maxs) - np.array(mins)
-        warnings.warn(f"Estimated shape {shape}")
-    else:
-        shape = np.asarray(shape) - 1
-
-    traj /= np.asarray(shape)
-    return np.squeeze(traj)

--- a/src/mrinufft/operators/interfaces/bart.py
+++ b/src/mrinufft/operators/interfaces/bart.py
@@ -10,12 +10,8 @@ import os
 import subprocess as subp
 import tempfile
 from pathlib import Path
-
-import numpy as np
-
-from mrinufft.io.cfl import _readcfl, _writecfl, traj2cfl
-
-from ..base import FourierOperatorCPU, proper_trajectory
+from mrinufft._utils import proper_trajectory
+from mrinufft.operators.base import FourierOperatorCPU
 
 # available if return code is 0
 BART_AVAILABLE = not subp.call(

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -625,6 +625,8 @@ class MRICufiNUFFT(FourierOperatorBase):
         T, B, C = self.n_trans, self.n_batchs, self.n_coils
         K, XYZ = self.n_samples, self.shape
 
+        image_data = cp.asarray(image_data)
+        obs_data = cp.asarray(obs_data)
         image_dataf = cp.reshape(image_data, (B, *XYZ))
         obs_dataf = cp.reshape(obs_data, (B * C, K))
         data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
@@ -689,6 +691,9 @@ class MRICufiNUFFT(FourierOperatorBase):
         """Calibrationless Gradient computation when all data is on device."""
         T, B, C = self.n_trans, self.n_batchs, self.n_coils
         K, XYZ = self.n_samples, self.shape
+
+        image_data = cp.asarray(image_data)
+        obs_data = cp.asarray(obs_data)
 
         data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
         ksp_batched = cp.empty((T, K), dtype=self.cpx_dtype)

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -523,7 +523,7 @@ class MRICufiNUFFT(FourierOperatorBase):
             ret = self.raw_op.type1(coeffs_d, image_d)
         return ret
 
-    def data_consistency(self, image_data, obs_data):
+    def get_grad(self, image_data, obs_data):
         """Compute the gradient estimation directly on gpu.
 
         This mixes the op and adj_op method to perform F_adj(F(x-y))

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -217,7 +217,8 @@ class MRICufiNUFFT(FourierOperatorBase):
             self.density = density
         else:
             self.compute_density(density)
-            self.density = cp.array(density)
+            if is_host_array(self.density):
+                self.density = cp.array(self.density)
 
         # Smaps support
         self.smaps = smaps

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -2,7 +2,9 @@
 
 import warnings
 import numpy as np
-from ..base import FourierOperatorBase, proper_trajectory
+from mrinufft.operators.base import FourierOperatorBase
+from mrinufft._utils import proper_trajectory
+
 from .utils import (
     CUPY_AVAILABLE,
     check_size,

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -213,12 +213,11 @@ class MRICufiNUFFT(FourierOperatorBase):
         self.dtype = self.samples.dtype
 
         # density compensation support
-        if density is True:
-            self.density = self.pipe(self.samples, shape)
-        elif is_host_array(density) or is_cuda_array(density):
-            self.density = cp.array(density)
+        if is_cuda_array(density):
+            self.density = density
         else:
-            self.density = None
+            self.compute_density(density)
+            self.density = cp.array(density)
 
         # Smaps support
         self.smaps = smaps

--- a/src/mrinufft/operators/interfaces/finufft.py
+++ b/src/mrinufft/operators/interfaces/finufft.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 
-from ..base import FourierOperatorCPU, proper_trajectory
+from mrinufft._utils import proper_trajectory
+from mrinufft.operators.base import FourierOperatorCPU
 
 FINUFFT_AVAILABLE = True
 try:

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -228,12 +228,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
         self.dtype = self.samples.dtype
         self.n_coils = n_coils
         self.smaps = smaps
-        if density is True:
-            self.density = self.pipe(self.samples, shape)
-        elif isinstance(density, np.ndarray):
-            self.density = density
-        else:
-            self.density = None
+        self.compute_density()
         self.kwargs = kwargs
         self.impl = RawGpuNUFFT(
             samples=self.samples,

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -1,6 +1,7 @@
 """Interface to the GPU NUFFT library."""
 
 import numpy as np
+import warnings
 from ..base import FourierOperatorBase, proper_trajectory
 
 GPUNUFFT_AVAILABLE = True
@@ -8,6 +9,42 @@ try:
     from gpuNUFFT import NUFFTOp
 except ImportError:
     GPUNUFFT_AVAILABLE = False
+
+CUPY_AVAILABLE = True
+try:
+    import cupyx as cx
+    import cupy as cp
+except ImportError:
+    CUPY_AVAILABLE = False
+
+
+def _allocator(size):
+    """Allocate pinned memory which is context portable."""
+    flags = cp.cuda.runtime.hostAllocPortable
+    mem = cp.cuda.PinnedMemory(size, flags=flags)
+    return cp.cuda.PinnedMemoryPointer(mem, offset=0)
+
+
+def make_pinned_smaps(smaps):
+    """Make pinned smaps from smaps.
+
+    Parameters
+    ----------
+    smaps: np.ndarray or None
+        the sensitivity maps
+
+    Returns
+    -------
+    np.ndarray or None
+        the pinned sensitivity maps
+    """
+    if smaps is None:
+        return None
+    smaps_ = smaps.T.reshape(-1, smaps.shape[0])
+    cp.cuda.set_pinned_memory_allocator(_allocator)
+    pinned_smaps = cx.empty_pinned(smaps_.shape, dtype=np.complex64, order="F")
+    np.copyto(pinned_smaps, smaps_)
+    return pinned_smaps
 
 
 class RawGpuNUFFT:
@@ -40,6 +77,8 @@ class RawGpuNUFFT:
         balance_workload=True,
         smaps=None,
         pinned_smaps=None,
+        pinned_image=None,
+        pinned_kspace=None,
     ):
         """Initialize the 'NUFFT' class.
 
@@ -84,29 +123,50 @@ class RawGpuNUFFT:
             raise ValueError("The number of coils should be an integer >= 1")
         self.n_coils = n_coils
         self.shape = shape
-        self.samples = proper_trajectory(samples, normalize="unit")
+        self.samples = samples
         if density_comp is None:
             density_comp = np.ones(samples.shape[0])
-
-        self.uses_sense = True
-        if smaps is not None and pinned_smaps is None:
-            # no pinning provided, we will pin it in the C++ code
-            pinned_smaps = smaps.T.reshape(-1, n_coils)
-        elif smaps is not None and pinned_smaps is not None:
-            # Pinned memory space exists, we will overwrite it
-            np.copyto(pinned_smaps, smaps.T.reshape(-1, n_coils))
-        else:
-            # No smaps provided, we will not use SENSE
-            self.uses_sense = False
 
         if upsampfac is not None:
             osf = upsampfac
 
+        # pinned memory stuff
+        self.uses_sense = True
+        if smaps is not None and pinned_smaps is None:
+            pinned_smaps = make_pinned_smaps(smaps)
+            warnings.warn("no pinning provided, pinning existing smaps now.")
+        elif smaps is not None and pinned_smaps is not None:
+            # Pinned memory space exists, we will overwrite it
+            np.copyto(pinned_smaps, smaps.T.reshape(-1, n_coils))
+            warnings.warn("Overwriting the pinned data.")
+        elif smaps is None and pinned_smaps is None:
+            # No smaps provided, we will not use SENSE
+            self.uses_sense = False
+        elif smaps is None and pinned_smaps is not None:
+            warnings.warn("Using pinned_smaps as is.")
+        else:
+            raise ValueError("Unknown case")
+
+        if pinned_image is None:
+            pinned_image = cx.empty_pinned(
+                (np.prod(shape), (1 if self.uses_sense else n_coils)),
+                dtype=np.complex64,
+                order="F",
+            )
+        if pinned_kspace is None:
+            pinned_kspace = cx.empty_pinned(
+                (n_coils, len(samples)),
+                dtype=np.complex64,
+            )
+        self.pinned_image = pinned_image
+        self.pinned_kspace = pinned_kspace
+
+        self.pinned_smaps = pinned_smaps
         self.operator = NUFFTOp(
             np.reshape(samples, samples.shape[::-1], order="F"),
-            shape,
-            n_coils,
-            pinned_smaps,
+            self.shape,
+            self.n_coils,
+            self.pinned_smaps,
             density_comp,
             kernel_width,
             sector_width,
@@ -114,7 +174,7 @@ class RawGpuNUFFT:
             balance_workload,
         )
 
-    def op(self, image, interpolate_data=False):
+    def op(self, image, kspace=None, interpolate_data=False):
         """Compute the masked non-Cartesian Fourier transform.
 
         Parameters
@@ -133,28 +193,36 @@ class RawGpuNUFFT:
         # Base gpuNUFFT Operator is written in CUDA and C++, we need to
         # reorganize data to follow a different memory hierarchy
         # TODO we need to update codes to use np.reshape for all this directly
-        if self.n_coils > 1 and not self.uses_sense:
-            coeff = self.operator.op(
-                np.asarray(
-                    [np.reshape(image_ch.T, image_ch.size) for image_ch in image]
-                ).T,
-                interpolate_data,
+        make_copy_back = False
+        if kspace is None:
+            kspace = self.pinned_kspace
+            make_copy_back = True
+        if self.uses_sense or self.n_coils == 1:
+            np.copyto(
+                self.pinned_image,
+                np.reshape(image, (-1, 1), "F"),
             )
         else:
-            coeff = self.operator.op(np.reshape(image.T, image.size), interpolate_data)
-            # Data is always returned as num_channels X coeff_array,
-            # so for single channel, we extract single array
-            if not self.uses_sense:
-                coeff = coeff[0]
-        return coeff
+            np.copyto(
+                self.pinned_image,
+                np.asarray([np.ravel(c, order="F") for c in image]).T,
+            )
+        new_ksp = self.operator.op(
+            self.pinned_image,
+            kspace,
+            interpolate_data,
+        )
+        if make_copy_back:
+            new_ksp = np.copy(new_ksp)
+        return new_ksp
 
-    def adj_op(self, coeff, grid_data=False):
+    def adj_op(self, coeffs, image=None, grid_data=False):
         """Compute adjoint of non-uniform Fourier transform.
 
         Parameters
         ----------
         coeff: np.ndarray
-            masked non-uniform Fourier transform 1D data.
+            masked non-uniform Fourier transform data.
         grid_data: bool, default False
             if True, the kspace data is gridded and returned,
             this is used for density compensation
@@ -165,14 +233,18 @@ class RawGpuNUFFT:
             adjoint operator of Non Uniform Fourier transform of the
             input coefficients.
         """
-        image = self.operator.adj_op(coeff, grid_data)
-        if self.n_coils > 1 and not self.uses_sense:
-            image = np.asarray([image_ch.T for image_ch in image])
-        else:
-            image = np.squeeze(image).T
-        # The recieved data from gpuNUFFT is num_channels x Nx x Ny x Nz,
-        # hence we use squeeze
-        return np.squeeze(image)
+        make_copy_back = False
+        if image is None:
+            image = self.pinned_image
+            make_copy_back = True
+        np.copyto(self.pinned_kspace, coeffs)
+        new_image = self.operator.adj_op(self.pinned_kspace, image, grid_data)
+        if make_copy_back:
+            new_image = np.copy(new_image)
+        if self.uses_sense or self.n_coils == 1:
+            return np.squeeze(new_image).T
+
+        return np.asarray([c.T for c in new_image])
 
 
 class MRIGpuNUFFT(FourierOperatorBase):
@@ -203,7 +275,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
     """
 
     backend = "gpunufft"
-    available = GPUNUFFT_AVAILABLE
+    available = GPUNUFFT_AVAILABLE and CUPY_AVAILABLE
 
     def __init__(
         self,
@@ -244,7 +316,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
             **self.kwargs,
         )
 
-    def op(self, data, *args):
+    def op(self, data, *args, **kwargs):
         """Compute forward non-uniform Fourier Transform.
 
         Parameters
@@ -257,9 +329,9 @@ class MRIGpuNUFFT(FourierOperatorBase):
         np.ndarray
             Masked Fourier transform of the input image.
         """
-        return self.impl.op(data, *args)
+        return self.impl.op(data, *args, **kwargs)
 
-    def adj_op(self, coeffs, *args):
+    def adj_op(self, coeffs, *args, **kwargs):
         """Compute adjoint Non Unform Fourier Transform.
 
         Parameters
@@ -272,7 +344,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
         np.ndarray
             Inverse discrete Fourier transform of the input coefficients.
         """
-        return self.impl.adj_op(coeffs, *args)
+        return self.impl.adj_op(coeffs, *args, **kwargs)
 
     @property
     def uses_sense(self):

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -228,7 +228,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
         self.dtype = self.samples.dtype
         self.n_coils = n_coils
         self.smaps = smaps
-        self.compute_density()
+        self.compute_density(density)
         self.kwargs = kwargs
         self.impl = RawGpuNUFFT(
             samples=self.samples,
@@ -276,7 +276,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
         return self.impl.uses_sense
 
     @classmethod
-    def pipe(cls, kspace_loc, volume_shape, num_iterations=10):
+    def pipe(cls, kspace_loc, volume_shape, num_iterations=10, **kwargs):
         """Compute the density compensation weights for a given set of kspace locations.
 
         Parameters
@@ -292,11 +292,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
             raise ValueError(
                 "gpuNUFFT is not available, cannot " "estimate the density compensation"
             )
-        grid_op = MRIGpuNUFFT(
-            samples=kspace_loc,
-            shape=volume_shape,
-            osf=1,
-        )
+        grid_op = MRIGpuNUFFT(samples=kspace_loc, shape=volume_shape, **kwargs)
         density_comp = np.ones(kspace_loc.shape[0])
         for _ in range(num_iterations):
             density_comp = density_comp / np.abs(

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -1,50 +1,14 @@
 """Interface to the GPU NUFFT library."""
 
 import numpy as np
-import warnings
-from ..base import FourierOperatorBase, proper_trajectory
+from mrinufft._utils import proper_trajectory
+from mrinufft.operators.base import FourierOperatorBase
 
 GPUNUFFT_AVAILABLE = True
 try:
     from gpuNUFFT import NUFFTOp
 except ImportError:
     GPUNUFFT_AVAILABLE = False
-
-CUPY_AVAILABLE = True
-try:
-    import cupyx as cx
-    import cupy as cp
-except ImportError:
-    CUPY_AVAILABLE = False
-
-
-def _allocator(size):
-    """Allocate pinned memory which is context portable."""
-    flags = cp.cuda.runtime.hostAllocPortable
-    mem = cp.cuda.PinnedMemory(size, flags=flags)
-    return cp.cuda.PinnedMemoryPointer(mem, offset=0)
-
-
-def make_pinned_smaps(smaps):
-    """Make pinned smaps from smaps.
-
-    Parameters
-    ----------
-    smaps: np.ndarray or None
-        the sensitivity maps
-
-    Returns
-    -------
-    np.ndarray or None
-        the pinned sensitivity maps
-    """
-    if smaps is None:
-        return None
-    smaps_ = smaps.T.reshape(-1, smaps.shape[0])
-    cp.cuda.set_pinned_memory_allocator(_allocator)
-    pinned_smaps = cx.empty_pinned(smaps_.shape, dtype=np.complex64, order="F")
-    np.copyto(pinned_smaps, smaps_)
-    return pinned_smaps
 
 
 class RawGpuNUFFT:
@@ -77,8 +41,6 @@ class RawGpuNUFFT:
         balance_workload=True,
         smaps=None,
         pinned_smaps=None,
-        pinned_image=None,
-        pinned_kspace=None,
     ):
         """Initialize the 'NUFFT' class.
 
@@ -123,50 +85,29 @@ class RawGpuNUFFT:
             raise ValueError("The number of coils should be an integer >= 1")
         self.n_coils = n_coils
         self.shape = shape
-        self.samples = samples
+        self.samples = proper_trajectory(samples, normalize="unit")
         if density_comp is None:
             density_comp = np.ones(samples.shape[0])
+
+        self.uses_sense = True
+        if smaps is not None and pinned_smaps is None:
+            # no pinning provided, we will pin it in the C++ code
+            pinned_smaps = smaps.T.reshape(-1, n_coils)
+        elif smaps is not None and pinned_smaps is not None:
+            # Pinned memory space exists, we will overwrite it
+            np.copyto(pinned_smaps, smaps.T.reshape(-1, n_coils))
+        else:
+            # No smaps provided, we will not use SENSE
+            self.uses_sense = False
 
         if upsampfac is not None:
             osf = upsampfac
 
-        # pinned memory stuff
-        self.uses_sense = True
-        if smaps is not None and pinned_smaps is None:
-            pinned_smaps = make_pinned_smaps(smaps)
-            warnings.warn("no pinning provided, pinning existing smaps now.")
-        elif smaps is not None and pinned_smaps is not None:
-            # Pinned memory space exists, we will overwrite it
-            np.copyto(pinned_smaps, smaps.T.reshape(-1, n_coils))
-            warnings.warn("Overwriting the pinned data.")
-        elif smaps is None and pinned_smaps is None:
-            # No smaps provided, we will not use SENSE
-            self.uses_sense = False
-        elif smaps is None and pinned_smaps is not None:
-            warnings.warn("Using pinned_smaps as is.")
-        else:
-            raise ValueError("Unknown case")
-
-        if pinned_image is None:
-            pinned_image = cx.empty_pinned(
-                (np.prod(shape), (1 if self.uses_sense else n_coils)),
-                dtype=np.complex64,
-                order="F",
-            )
-        if pinned_kspace is None:
-            pinned_kspace = cx.empty_pinned(
-                (n_coils, len(samples)),
-                dtype=np.complex64,
-            )
-        self.pinned_image = pinned_image
-        self.pinned_kspace = pinned_kspace
-
-        self.pinned_smaps = pinned_smaps
         self.operator = NUFFTOp(
             np.reshape(samples, samples.shape[::-1], order="F"),
-            self.shape,
-            self.n_coils,
-            self.pinned_smaps,
+            shape,
+            n_coils,
+            pinned_smaps,
             density_comp,
             kernel_width,
             sector_width,
@@ -174,7 +115,7 @@ class RawGpuNUFFT:
             balance_workload,
         )
 
-    def op(self, image, kspace=None, interpolate_data=False):
+    def op(self, image, interpolate_data=False):
         """Compute the masked non-Cartesian Fourier transform.
 
         Parameters
@@ -193,36 +134,28 @@ class RawGpuNUFFT:
         # Base gpuNUFFT Operator is written in CUDA and C++, we need to
         # reorganize data to follow a different memory hierarchy
         # TODO we need to update codes to use np.reshape for all this directly
-        make_copy_back = False
-        if kspace is None:
-            kspace = self.pinned_kspace
-            make_copy_back = True
-        if self.uses_sense or self.n_coils == 1:
-            np.copyto(
-                self.pinned_image,
-                np.reshape(image, (-1, 1), "F"),
+        if self.n_coils > 1 and not self.uses_sense:
+            coeff = self.operator.op(
+                np.asarray(
+                    [np.reshape(image_ch.T, image_ch.size) for image_ch in image]
+                ).T,
+                interpolate_data,
             )
         else:
-            np.copyto(
-                self.pinned_image,
-                np.asarray([np.ravel(c, order="F") for c in image]).T,
-            )
-        new_ksp = self.operator.op(
-            self.pinned_image,
-            kspace,
-            interpolate_data,
-        )
-        if make_copy_back:
-            new_ksp = np.copy(new_ksp)
-        return new_ksp
+            coeff = self.operator.op(np.reshape(image.T, image.size), interpolate_data)
+            # Data is always returned as num_channels X coeff_array,
+            # so for single channel, we extract single array
+            if not self.uses_sense:
+                coeff = coeff[0]
+        return coeff
 
-    def adj_op(self, coeffs, image=None, grid_data=False):
+    def adj_op(self, coeff, grid_data=False):
         """Compute adjoint of non-uniform Fourier transform.
 
         Parameters
         ----------
         coeff: np.ndarray
-            masked non-uniform Fourier transform data.
+            masked non-uniform Fourier transform 1D data.
         grid_data: bool, default False
             if True, the kspace data is gridded and returned,
             this is used for density compensation
@@ -233,18 +166,14 @@ class RawGpuNUFFT:
             adjoint operator of Non Uniform Fourier transform of the
             input coefficients.
         """
-        make_copy_back = False
-        if image is None:
-            image = self.pinned_image
-            make_copy_back = True
-        np.copyto(self.pinned_kspace, coeffs)
-        new_image = self.operator.adj_op(self.pinned_kspace, image, grid_data)
-        if make_copy_back:
-            new_image = np.copy(new_image)
-        if self.uses_sense or self.n_coils == 1:
-            return np.squeeze(new_image).T
-
-        return np.asarray([c.T for c in new_image])
+        image = self.operator.adj_op(coeff, grid_data)
+        if self.n_coils > 1 and not self.uses_sense:
+            image = np.asarray([image_ch.T for image_ch in image])
+        else:
+            image = np.squeeze(image).T
+        # The recieved data from gpuNUFFT is num_channels x Nx x Ny x Nz,
+        # hence we use squeeze
+        return np.squeeze(image)
 
 
 class MRIGpuNUFFT(FourierOperatorBase):
@@ -275,7 +204,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
     """
 
     backend = "gpunufft"
-    available = GPUNUFFT_AVAILABLE and CUPY_AVAILABLE
+    available = GPUNUFFT_AVAILABLE
 
     def __init__(
         self,
@@ -316,7 +245,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
             **self.kwargs,
         )
 
-    def op(self, data, *args, **kwargs):
+    def op(self, data, *args):
         """Compute forward non-uniform Fourier Transform.
 
         Parameters
@@ -329,9 +258,9 @@ class MRIGpuNUFFT(FourierOperatorBase):
         np.ndarray
             Masked Fourier transform of the input image.
         """
-        return self.impl.op(data, *args, **kwargs)
+        return self.impl.op(data, *args)
 
-    def adj_op(self, coeffs, *args, **kwargs):
+    def adj_op(self, coeffs, *args):
         """Compute adjoint Non Unform Fourier Transform.
 
         Parameters
@@ -344,7 +273,7 @@ class MRIGpuNUFFT(FourierOperatorBase):
         np.ndarray
             Inverse discrete Fourier transform of the input coefficients.
         """
-        return self.impl.adj_op(coeffs, *args, **kwargs)
+        return self.impl.adj_op(coeffs, *args)
 
     @property
     def uses_sense(self):

--- a/src/mrinufft/operators/interfaces/sigpy.py
+++ b/src/mrinufft/operators/interfaces/sigpy.py
@@ -5,7 +5,8 @@ The SigPy NUFFT is fully implemented in Python.
 import warnings
 
 import numpy as np
-from ..base import FourierOperatorCPU, proper_trajectory
+from mrinufft._utils import proper_trajectory
+from mrinufft.operators.base import FourierOperatorCPU
 
 
 SIGPY_AVAILABLE = True

--- a/src/mrinufft/operators/interfaces/tfnufft.py
+++ b/src/mrinufft/operators/interfaces/tfnufft.py
@@ -118,7 +118,7 @@ class MRITensorflowNUFFT(FourierOperatorBase):
         )
         return tf.math.reduce_sum(img * tf.math.conj(self.smaps), axis=0)
 
-    def data_consistency(self, data, obs_data):
+    def get_grad(self, data, obs_data):
         """Compute the data consistency.
 
         Parameters

--- a/src/mrinufft/operators/off_resonnance.py
+++ b/src/mrinufft/operators/off_resonnance.py
@@ -102,7 +102,7 @@ class MRIFourierCorrected(FourierOperatorBase):
             return y
         return y.get()
 
-    def data_consistency(self, image_data, obs_data):
+    def get_grad(self, image_data, obs_data):
         """Compute the data consistency error.
 
         Parameters

--- a/src/mrinufft/operators/stacked.py
+++ b/src/mrinufft/operators/stacked.py
@@ -4,8 +4,9 @@ import warnings
 import numpy as np
 import scipy as sp
 
-from .base import FourierOperatorBase, check_backend, get_operator, proper_trajectory
-from .interfaces.utils import (
+from mrinufft._utils import proper_trajectory
+from mrinufft.operators.base import FourierOperatorBase, check_backend, get_operator
+from mrinufft.operators.interfaces.utils import (
     is_cuda_array,
     is_host_array,
     pin_memory,

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -9,7 +9,7 @@ from case_trajectories import CasesTrajectories
 from helpers import assert_correlate
 from mrinufft.density import cell_count, voronoi
 from mrinufft.density.utils import normalize_weights
-from mrinufft.operators import proper_trajectory
+from mrinufft._utils import proper_trajectory
 
 
 def slow_cell_count2D(traj, shape, osf):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,6 @@
 """Test the trajectories io module."""
 import numpy as np
-from mrinufft.trajectories.io import read_trajectory, write_trajectory
+from mrinufft.io import read_trajectory, write_trajectory
 from mrinufft.trajectories.trajectory2D import initialize_2D_radial
 from mrinufft.trajectories.trajectory3D import initialize_3D_cones
 from pytest_cases import parametrize_with_cases


### PR DESCRIPTION

**This PR add support for pytorch in mri-nufft**

Currently only cufinufft can use torch's Tensor on GPU (i.e. device="cuda"). 

Feature to implement: 

- [X] Tensor for Cufinufft op/adj_op  (input/output)
- [X] Dtype Conversion
- [ ] Tensor for input smaps 
- [ ] Tensor for input samples point.
- [ ] Tensor for CPU-based nufft.
- [ ] Tensor Support for Stacked-Nufft.

The point of this PR is NOT to add autodiff support.

NB: This is built on top of the `density_register` branch. 