### PR TITLE
Spiral patch

### DIFF
--- a/examples/example_2D_trajectories.py
+++ b/examples/example_2D_trajectories.py
@@ -23,6 +23,7 @@ import numpy as np
 
 # Internal
 import mrinufft as mn
+import mrinufft.trajectories.maths as mntm
 
 from mrinufft import display_2D_trajectory
 
@@ -169,7 +170,7 @@ show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_s
 # ------
 #
 # A generalized function that generates algebraic spirals defined
-# through the :math:`r = a \theta^n` equality, with :math:`r` the radius,
+# through the :math:`r = a \theta^n` equation, with :math:`r` the radius,
 # :math:`\theta` the polar angle and :math:`n` the spiral power.
 # Common algebraic spirals include Archimedes, Fermat and Galilean spirals.
 #
@@ -214,14 +215,112 @@ show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_s
 # :math:`r = a \theta^n` equality, with :math:`r` the radius and
 # :math:`\theta` the polar angle. It defines the gradient behavior,
 # and therefore the distance between consecutive points and the shape
-# of the spiral.
+# of the spiral. It does not affect the number of revolutions, but
+# rather the curve length and point distribution. Spirals with small
+# :math:`n` (close to 0) tend to have radial behaviors
+# around the center, and dedicate more points towards curved edges.
 # 
-# ``"archimedes"``, ``"fermat"`` and ``"galilean"`` are available
-# as string options for convenience.
+# ``"archimedes"`` (1), ``"fermat"`` (0.5) and ``"galilean"`` (2) are available
+# as string options for convenience. Algebraic spirals with negative powers,
+# such as hyperbolic or lithuus spirals, are not considered relevant because
+# of their asymptotic behavior around the center.
 #
 
 arguments = ["galilean", "archimedes", "fermat", 1 / 4]
 function = lambda x: mn.initialize_2D_spiral(Nc, Ns, tilt=tilt, spiral=x, in_out=in_out)
+show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_size)
+
+
+# %%
+# ``patch_center (float)``
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# A slew rate anomaly is present at the center of algebraic spirals
+# when their power is inferior to 1 (e.g. Fermat's) and parameterized
+# through their angles in the above equation.
+#
+# To fix this problem, points at the center are re-arranged along
+# the spiral until the gradients are monotically increasing from
+# the center to the edges. This correction can be deactivated,
+# but it is generally preferred to keep it.
+#
+# The spiral path is not changed, but the density can be altered
+# over the first few samples. However the difference is extremely
+# subtle, as shown below.
+#
+
+arguments = [False, True]
+function = lambda x: mn.initialize_2D_spiral(
+    Nc, Ns, patch_center=x,
+)
+show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_size)
+
+
+# %%
+# Fibonacci spiral
+# ----------------
+#
+# A non-algebraic spiral trajectory based on the Fibonacci sequence,
+# reproducing the proposition from [CA99]_ in order to generate
+# a uniform distribution with center-out shots.
+#
+# The number of shots is required to belong to the Fibonacci
+# sequence for the trajectory definition to be relevant.
+#
+# Arguments:
+#
+# - ``Nc (int)``: number of individual shots. See radial
+# - ``Ns (int)``: number of samples per shot. See radial
+# - ``spiral_reduction (float)``: factor used to reduce the automatic spiral length. ``(default 1)``
+# - ``patch_center (bool)``: whether the spiral anomaly at the center should be patched.
+#   ``(default True)``
+#
+
+Nc_fibonacci = mntm.get_closest_fibonacci_number(Nc)
+trajectory = mn.initialize_2D_fibonacci_spiral(Nc_fibonacci, Ns)
+show_trajectory(trajectory, figure_size=figure_size, one_shot=one_shot)
+
+
+# %%
+# ``spiral_reduction (float)``
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Factor used to reduce the automatic spiral length. In opposition to
+# ``initialize_2D_spiral``, the number of spiral revolutions here
+# is automatically determined from ``Ns`` and ``Nc`` to match a uniform
+# density over the k-space sphere. It can lead to unrealistically
+# strong gradients, and therefore we provide this factor to reduce the
+# spiral length, which makes k-space denser along the shorter shots.
+#
+
+arguments = [0.5, 1, 2, 3]
+function = lambda x: mn.initialize_2D_fibonacci_spiral(
+    Nc_fibonacci, Ns, spiral_reduction=x,
+)
+show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_size)
+
+
+# %%
+# ``patch_center (float)``
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Similarly to algebraic spirals from ``initialize_2D_spiral``,
+# the trajectory definition creates small anomalies at the center
+# that makes slew rate requirements needlessly high.
+#
+# It is here related to the uniform density that requires central
+# samples to be more strongly spaced than anywhere else because
+# most shots start close to the center.
+#
+# The spiral path can be altered over the first few samples,
+# but generally the difference is extremely subtle, as shown
+# below.
+#
+
+arguments = [False, True]
+function = lambda x: mn.initialize_2D_fibonacci_spiral(
+    Nc_fibonacci, Ns, patch_center=x,
+)
 show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_size)
 
 

--- a/examples/example_2D_trajectories.py
+++ b/examples/example_2D_trajectories.py
@@ -168,10 +168,10 @@ show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_s
 # Spiral
 # ------
 #
-# A generalized function that generates spirals defined through the
-# :math:`r = a \theta^{1/n}` equality, with :math:`r` the radius and
-# :math:`\theta` the polar angle. Note that the most common spirals,
-# Archimedes and Fermat, are subcases of this equation.
+# A generalized function that generates algebraic spirals defined
+# through the :math:`r = a \theta^n` equality, with :math:`r` the radius,
+# :math:`\theta` the polar angle and :math:`n` the spiral power.
+# Common algebraic spirals include Archimedes, Fermat and Galilean spirals.
 #
 # Arguments:
 #
@@ -210,14 +210,17 @@ show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_s
 # ``spiral (str, float)``
 # ~~~~~~~~~~~~~~~~~~~~~~~
 #
-#
-# The shape of the spiral defined through :math:`n` in the
-# :math:`r = a \theta^{1/n}` equality, with :math:`r` the radius and
-# :math:`\theta` the polar angle. Both ``"archimedes"`` and ``"fermat"``
-# are available as string options for convenience.
+# The algebraic spiral power defined through :math:`n` in the
+# :math:`r = a \theta^n` equality, with :math:`r` the radius and
+# :math:`\theta` the polar angle. It defines the gradient behavior,
+# and therefore the distance between consecutive points and the shape
+# of the spiral.
+# 
+# ``"archimedes"``, ``"fermat"`` and ``"galilean"`` are available
+# as string options for convenience.
 #
 
-arguments = ["archimedes", "fermat", 0.5, 1.5]
+arguments = ["galilean", "archimedes", "fermat", 1 / 4]
 function = lambda x: mn.initialize_2D_spiral(Nc, Ns, tilt=tilt, spiral=x, in_out=in_out)
 show_argument(function, arguments, one_shot=one_shot, subfigure_size=subfigure_size)
 

--- a/src/mrinufft/__init__.py
+++ b/src/mrinufft/__init__.py
@@ -15,6 +15,7 @@ from .operators import (
 from .trajectories import (
     initialize_2D_radial,
     initialize_2D_spiral,
+    initialize_2D_fibonacci_spiral,
     initialize_2D_cones,
     initialize_2D_sinusoide,
     initialize_2D_propeller,
@@ -51,6 +52,7 @@ __all__ = [
     "list_backends",
     "initialize_2D_radial",
     "initialize_2D_spiral",
+    "initialize_2D_fibonacci_spiral",
     "initialize_2D_cones",
     "initialize_2D_sinusoide",
     "initialize_2D_propeller",
@@ -75,6 +77,7 @@ __all__ = [
     "shellify",
     "duplicate_along_axes",
     "radialize_center",
+    "patch_center_anomaly",
     "displayConfig",
     "display_2D_trajectory",
     "display_3D_trajectory",

--- a/src/mrinufft/trajectories/__init__.py
+++ b/src/mrinufft/trajectories/__init__.py
@@ -40,6 +40,8 @@ from .display import (
     display_3D_trajectory,
 )
 
+from .gradients import patch_center_monoticity
+
 __all__ = [
     "initialize_2D_radial",
     "initialize_2D_spiral",
@@ -70,4 +72,5 @@ __all__ = [
     "displayConfig",
     "display_2D_trajectory",
     "display_3D_trajectory",
+    "patch_center_monoticity",
 ]

--- a/src/mrinufft/trajectories/__init__.py
+++ b/src/mrinufft/trajectories/__init__.py
@@ -3,6 +3,7 @@
 from .trajectory2D import (
     initialize_2D_radial,
     initialize_2D_spiral,
+    initialize_2D_fibonacci_spiral,
     initialize_2D_cones,
     initialize_2D_sinusoide,
     initialize_2D_propeller,
@@ -40,11 +41,12 @@ from .display import (
     display_3D_trajectory,
 )
 
-from .gradients import patch_center_monoticity
+from .gradients import patch_center_anomaly
 
 __all__ = [
     "initialize_2D_radial",
     "initialize_2D_spiral",
+    "initialize_2D_fibonacci_spiral",
     "initialize_2D_cones",
     "initialize_2D_sinusoide",
     "initialize_2D_propeller",
@@ -72,5 +74,5 @@ __all__ = [
     "displayConfig",
     "display_2D_trajectory",
     "display_3D_trajectory",
-    "patch_center_monoticity",
+    "patch_center_anomaly",
 ]

--- a/src/mrinufft/trajectories/display.py
+++ b/src/mrinufft/trajectories/display.py
@@ -1,4 +1,4 @@
-"""Display function for trajectories."""
+"""Display functions for trajectories."""
 
 import itertools
 

--- a/src/mrinufft/trajectories/gradients.py
+++ b/src/mrinufft/trajectories/gradients.py
@@ -1,0 +1,40 @@
+import numpy as np
+import numpy.linalg as nl
+from scipy.interpolate import CubicSpline
+
+
+def patch_center_monoticity(parameters, update_shot, update_parameters, in_out=False, learning_rate=1e-1):
+    single_shot = update_shot(*parameters)
+    Ns = single_shot.shape[0]
+
+    old_index = 0
+    old_x_axis = np.zeros(Ns)
+    x_axis = np.linspace(0, 1, Ns)
+
+    while nl.norm(x_axis - old_x_axis) / Ns > 1e-10:
+        # Determine interval to fix
+        single_shot = update_shot(*parameters)
+        gradient_norm = nl.norm(np.diff(single_shot[(Ns // 2) * in_out:], axis=0), axis=-1)
+        arc_length = np.cumsum(gradient_norm)
+
+        index = gradient_norm[1:] - arc_length[1:] / (1 + np.arange(1, len(gradient_norm)))
+        index = np.where(index < 0, np.inf, index)
+        index = max(old_index, 2 + np.argmin(index))
+        start_index = (Ns // 2 + (Ns % 2) - index) * in_out
+        final_index = (Ns // 2) * in_out + index
+
+        # Balance over interval
+        cbs = CubicSpline(x_axis, single_shot.T, axis=1)
+        gradient_norm = nl.norm(np.diff(single_shot[start_index:final_index], axis=0), axis=-1)
+
+        old_x_axis = np.copy(x_axis)
+        new_x_axis = np.cumsum(np.diff(x_axis[start_index:final_index]) / gradient_norm)
+        new_x_axis *= (x_axis[final_index - 1] - x_axis[start_index]) / new_x_axis[-1]  # Normalize
+        new_x_axis += x_axis[start_index]
+        x_axis[start_index + 1:final_index - 1] += (new_x_axis[:-1] - x_axis[start_index + 1:final_index - 1]) * learning_rate
+
+        # Update loop variables
+        old_index = index
+        single_shot = cbs(x_axis).T
+        parameters = update_parameters(single_shot, *parameters)
+    return parameters

--- a/src/mrinufft/trajectories/gradients.py
+++ b/src/mrinufft/trajectories/gradients.py
@@ -1,23 +1,93 @@
+"""Functions to improve/modify gradients."""
+
 import numpy as np
 import numpy.linalg as nl
 from scipy.interpolate import CubicSpline
 
 
-def patch_center_monoticity(parameters, update_shot, update_parameters, in_out=False, learning_rate=1e-1):
-    single_shot = update_shot(*parameters)
+def patch_center_anomaly(
+    shot_or_params,
+    update_shot=None,
+    update_parameters=None,
+    in_out=False,
+    learning_rate=1e-1,
+):
+    """Re-position samples to avoid center anomalies.
+
+    Some trajectories behave slightly differently from expected when
+    approaching definition bounds, most often the k-space center as
+    for spirals in some cases.
+
+    This function enforces non-strictly increasing monoticity of
+    sample distances from the center, effectively reducing slew
+    rates and smoothing gradient transitions locally.
+
+    Shots can be updated with provided functions to keep fitting
+    their strict definition, or it can be smoothed using cubic
+    spline approximations.
+
+    Parameters
+    ----------
+    shot_or_params : np.array, list
+        Either a single shot of shape (Ns, Nd), or a list of arbitrary
+        arguments used by ``update_shot`` to initialize a single shot.
+    update_shot : function, optional
+        Function used to initialize a single shot based on parameters
+        provided by ``update_parameters``. If None, cubic splines are
+        used as an approximation instead, by default None
+    update_parameters : function, optional
+        Function used to update shot parameters when provided in
+        ``shot_or_params`` from an updated shot and parameters.
+        If None, cubic spline parameterization is used instead,
+        by default None
+    in_out : bool, optional
+        Whether the shot is going in-and-out or start from the center,
+        by default False
+    learning_rate : float, optional
+        Learning rate used in the iterative optimization process,
+        by default 1e-1
+
+    Returns
+    -------
+    array_like
+        N-D trajectory based on ``shot_or_params`` if a shot or
+        update_shot otherwise.
+    list
+        Updated parameters either in the ``shot_or_params`` format
+        if params, or cubic spline parameterization as an array of
+        floats between 0 and 1 otherwise.
+    """
+    if update_shot is None or update_parameters is None:
+        single_shot = shot_or_params
+    else:
+        parameters = shot_or_params
+        single_shot = update_shot(*parameters)
     Ns = single_shot.shape[0]
 
     old_index = 0
     old_x_axis = np.zeros(Ns)
     x_axis = np.linspace(0, 1, Ns)
 
+    if update_shot is None or update_parameters is None:
+
+        def _default_update_parameters(shot, *parameters):
+            return parameters
+
+        update_parameters = _default_update_parameters
+        parameters = [x_axis]
+        update_shot = CubicSpline(x_axis, single_shot)
+
     while nl.norm(x_axis - old_x_axis) / Ns > 1e-10:
         # Determine interval to fix
         single_shot = update_shot(*parameters)
-        gradient_norm = nl.norm(np.diff(single_shot[(Ns // 2) * in_out:], axis=0), axis=-1)
+        gradient_norm = nl.norm(
+            np.diff(single_shot[(Ns // 2) * in_out :], axis=0), axis=-1
+        )
         arc_length = np.cumsum(gradient_norm)
 
-        index = gradient_norm[1:] - arc_length[1:] / (1 + np.arange(1, len(gradient_norm)))
+        index = gradient_norm[1:] - arc_length[1:] / (
+            1 + np.arange(1, len(gradient_norm))
+        )
         index = np.where(index < 0, np.inf, index)
         index = max(old_index, 2 + np.argmin(index))
         start_index = (Ns // 2 + (Ns % 2) - index) * in_out
@@ -25,16 +95,24 @@ def patch_center_monoticity(parameters, update_shot, update_parameters, in_out=F
 
         # Balance over interval
         cbs = CubicSpline(x_axis, single_shot.T, axis=1)
-        gradient_norm = nl.norm(np.diff(single_shot[start_index:final_index], axis=0), axis=-1)
+        gradient_norm = nl.norm(
+            np.diff(single_shot[start_index:final_index], axis=0), axis=-1
+        )
 
         old_x_axis = np.copy(x_axis)
         new_x_axis = np.cumsum(np.diff(x_axis[start_index:final_index]) / gradient_norm)
-        new_x_axis *= (x_axis[final_index - 1] - x_axis[start_index]) / new_x_axis[-1]  # Normalize
+        new_x_axis *= (x_axis[final_index - 1] - x_axis[start_index]) / new_x_axis[
+            -1
+        ]  # Normalize
         new_x_axis += x_axis[start_index]
-        x_axis[start_index + 1:final_index - 1] += (new_x_axis[:-1] - x_axis[start_index + 1:final_index - 1]) * learning_rate
+        x_axis[start_index + 1 : final_index - 1] += (
+            new_x_axis[:-1] - x_axis[start_index + 1 : final_index - 1]
+        ) * learning_rate
 
         # Update loop variables
         old_index = index
         single_shot = cbs(x_axis).T
         parameters = update_parameters(single_shot, *parameters)
-    return parameters
+
+    single_shot = single_shot = update_shot(*parameters)
+    return single_shot, parameters

--- a/src/mrinufft/trajectories/maths.py
+++ b/src/mrinufft/trajectories/maths.py
@@ -210,6 +210,55 @@ def Ra(vector, theta):
 #############
 
 
+def is_from_fibonacci_sequence(n):
+    """Check if an integer belongs to the Fibonacci sequence.
+
+    An integer belongs to the Fibonacci sequence if either
+    :math:`5*n²+4` or :math:`5*n²-4` is a perfect square.
+
+    Parameters
+    ----------
+    n : int
+        Integer to check.
+
+    Returns
+    -------
+    bool
+        Whether or not ``n`` belongs to the Fibonacci sequence.
+    """
+
+    def _is_perfect_square(n):
+        r = int(np.sqrt(n))
+        return r * r == n
+
+    return _is_perfect_square(5 * n**2 + 4) or _is_perfect_square(5 * n**2 - 4)
+
+
+def get_closest_fibonacci_number(n):
+    """Provide the closest Fibonacci number.
+
+    Parameters
+    ----------
+    n : int
+        Integer to match.
+
+    Returns
+    -------
+    int
+        Closest number from the Fibonacci sequence.
+    """
+    # Generate Fibonacci number up to n
+    fibonacci_sequence = [0, 1]
+    while fibonacci_sequence[-1] < n:
+        fibonacci_sequence.append(fibonacci_sequence[-2] + fibonacci_sequence[-1])
+
+    # Check closest between the ones below and above n
+    lower_nf = fibonacci_sequence[-2]
+    upper_nf = fibonacci_sequence[-1]
+    nf = lower_nf if (n - lower_nf) < (upper_nf - n) else upper_nf
+    return nf
+
+
 def generate_fibonacci_lattice(nb_points, epsilon=0.25):
     """Generate 2D Cartesian coordinates using the Fibonacci lattice.
 

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -1,4 +1,4 @@
-"""Functions to manipulate trajectories."""
+"""Functions to manipulate/modify trajectories."""
 
 import numpy as np
 

--- a/src/mrinufft/trajectories/trajectory3D.py
+++ b/src/mrinufft/trajectories/trajectory3D.py
@@ -1,4 +1,4 @@
-"""3D Trajectory initialization functions."""
+"""Functions to initialize 3D trajectories."""
 
 import numpy as np
 import numpy.linalg as nl
@@ -411,8 +411,8 @@ def initialize_3D_helical_shells(
         Number of samples per shot
     nb_shells : int
         Number of concentric shells/spheres
-    spiral_reduction : float
-        Factor used to reduce the automatic spiral curvature, by default 1
+    spiral_reduction : float, optional
+        Factor used to reduce the automatic spiral length, by default 1
     shell_tilt : str, float, optional
         Angle between consecutive shells along z-axis, by default "intergaps"
     shot_tilt : str, float, optional

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for the trajectory design."""
+"""Utility functions in general."""
 
 from enum import Enum, EnumMeta
 from numbers import Real
@@ -71,6 +71,7 @@ class Spirals(FloatEnum):
     ARCHIMEDES = 1
     ARITHMETIC = ARCHIMEDES
     GALILEAN = 2
+    GALILEO = GALILEAN
     FERMAT = 0.5
     PARABOLIC = FERMAT
     HYPERBOLIC = -1

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -66,14 +66,15 @@ class Gammas(FloatEnum):
 
 
 class Spirals(FloatEnum):
-    """Enumerate spiral types."""
+    """Enumerate algebraic spiral types."""
 
     ARCHIMEDES = 1
     ARITHMETIC = ARCHIMEDES
-    FERMAT = 2
+    GALILEAN = 2
+    FERMAT = 0.5
     PARABOLIC = FERMAT
     HYPERBOLIC = -1
-    LITHUUS = -2
+    LITHUUS = -0.5
 
 
 class NormShapes(FloatEnum):
@@ -485,8 +486,8 @@ def initialize_tilt(tilt, nb_partitions=1):
         raise NotImplementedError(f"Unknown tilt name: {tilt}")
 
 
-def initialize_spiral(spiral):
-    """Initialize the spiral type.
+def initialize_algebraic_spiral(spiral):
+    """Initialize the algebraic spiral type.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR updates or adds the following features, summarized graphically in the picture down below:
1. **Update spiral parameterization from radial to polar**: Algebraic spirals (also known as [general archimedean spirals](https://en.wikipedia.org/wiki/Archimedean_spiral#General_Archimedean_spiral)) are usually defined in polar coordinate with the radius as a function of the polar angle (polar parameterization), but the opposite can be done too. It was a tricky question that was solved previously by defining the polar angle as a function of the radius (radial parameterization) because the implementation was convenient. However it makes the radius increase by a constant value, which leads to non-senses when referring to the literature, 3D FLORET in particular. Indeed, the goal of using Fermat spirals is to reduce the amount of points close to the center, increase them at the edges to achieve less central redundancy and a better edge coverage while decreasing the gradient strength required. The opposite happens with radial parameterization, and therefore it was changed to polar parameterization. This change mostly improve Fermat-based trajectories, while Archimedes spirals are not affected at all by this change. The power values were reversed to match this polar parameterization. However polar parameterization creates anomalies at the center for spirals with powers superior to 2 such as Fermat, fixed with a new feature explained below.
2. **Remove lithuus, hyperbolic and all spirals with negative powers**: Algebraic spirals with negative power values such as Lithuus or Hyperbolic spirals are irrelevant for MRI as their behavior is asymptotically chaotic when approaching the center, without possibility to fix it. The `initialize_2D_spiral` function now raises an error when negative values are given as arguments.
3. **Add 2D Fibonacci spiral trajectory**: Some literature also exists about non-algebraic spirals, and I proposed to reproduce the one from _Cline, Harvey E., and Thomas R. Anthony. "Uniform k-space sampling with an interleaved Fibonacci spiral acquisition." In Proceedings of the 7th Annual Meeting of ISMRM, Philadelphia, USA, vol. 1657. 1999._  as `initialize_2D_fibonacci_spiral`. The idea is to produce a strictly uniform density by using Fibonacci circle lattices, split into individual center-out spirals that are slightly eccentric to avoid redundancy. The number of spirals is required to be on the Fibonacci sequence, and therefore additional helper functions are provided in `mrinufft.trajectories.maths`.
4. **Add function to fix gradient central anomalies**: Most spiral-based trajectories from the literature have slew rate anomalies close to the center or poles (algebraic spirals with polar parameterization, Fibonacci spirals, Seiffert spirals, Concentric/Helical shells). A function is added to `mrinufft.trajectories.gradients` to enforce non-strictly increasing monoticity. This fix is added as an option to `initialize_2D_spirals` and `initialize_2D_fibonacci_spiral`, and will be added soon to `initialize_3D_seiffert_spiral` and `initialize_3D_helical_shell` in another PR.
5. **Add alias for Galilean spirals**: An alias is added for Galilean spirals, another type of algebraic spirals.

This PR is the first one to propose a function to adjust gradients, but more are coming as it is a major element of trajectory design, often present in the literature.

![Screenshot from 2024-05-19 15-29-01](https://github.com/mind-inria/mri-nufft/assets/20557033/057478c7-ca0f-4c8e-9623-937df1128ab3)