### PR TITLE
3D radial trajectory bundle (clean)

### DIFF
--- a/src/mrinufft/trajectories/maths.py
+++ b/src/mrinufft/trajectories/maths.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.linalg as nl
 
 CIRCLE_PACKING_DENSITY = np.pi / (2 * np.sqrt(3))
+EIGENVECTOR_2D_FIBONACCI = (0.4656, 0.6823, 1)
 
 
 ##########


### PR DESCRIPTION
This PR is a cleaned version of PR #113 and adds four 3D radial trajectories from the literature mentioned in issue #106:

1. `initialize_3D_phyllotaxis_radial` from "Spiral Phyllotaxis: The Natural Way to Construct a 3D Radial Trajectory in MRI" Davide Piccini et al. (2011). Radial shots are oriented following a Fibonacci sphere lattice.
2. `initialize_3D_golden_means_radial` from "Temporal Stability of Adaptive 3D Radial MRI Using Multidimensional Golden Means", Rachel W. Chan (2009). Radial shots are oriented following Fibonacci-based non-repeating angles.
3. `initialize_3D_wong_radial` from "A Strategy for Sampling on a Sphere Applied to 3D Selective RF Pulse Design", Sam T. S. Wong and Mark S. Roos (1994). Radial shots are oriented following one or multiple spiral(s) over the k-space sphere.
4. `initialize_3D_park_radial` from "A radial sampling strategy for uniform k-space coverage with retrospective respiratory gating in 3D ultrashort-echo-time lung imaging", Jinil Park et al. (2016). This pattern is based on Wong et al. (1994) from `initialize_3D_wong_radial`, enforcing a single spiral and ordering shots in a different way.

Documentation & examples coming soon.
The illustration below shows the tips of each radial shot for each of the four patterns.

![Screenshot from 2024-05-23 14-38-43](https://github.com/mind-inria/mri-nufft/assets/20557033/65b127bf-f0bd-479a-be64-a8310b35d5b9)
