### PR TITLE
remove use_smap + fix pipe test

### DIFF
--- a/src/mrinufft/operators/interfaces/tfnufft.py
+++ b/src/mrinufft/operators/interfaces/tfnufft.py
@@ -140,6 +140,7 @@ class MRITensorflowNUFFT(FourierOperatorBase):
         samples,
         shape,
         num_iterations,
+        osf=2,
         normalize=True,
     ):
         """Estimate the density compensation using the pipe method.
@@ -163,6 +164,8 @@ class MRITensorflowNUFFT(FourierOperatorBase):
             raise ValueError(
                 "tensorflow is not available, cannot estimate the density compensation"
             )
+        if osf != 2:
+            raise ValueError("Tensorflow does not support OSF != 2")
 
         density_comp = tf.math.reciprocal_no_nan(
             tfmri.estimate_density(samples, shape, method="pipe", max_iter=15)

--- a/tests/operators/test_density_for_op.py
+++ b/tests/operators/test_density_for_op.py
@@ -1,6 +1,7 @@
 """Specific test for testing densities specific to backend."""
 
 import numpy as np
+import pytest
 from pytest_cases import parametrize, parametrize_with_cases
 
 from case_trajectories import CasesTrajectories
@@ -27,8 +28,14 @@ def radial_distance(traj, shape):
 @parametrize(backend=["gpunufft", "tensorflow"])
 def test_pipe(backend, traj, shape, osf):
     """Test the pipe method."""
+    if backend == "tensorflow" and osf == 1:
+        result = pipe(traj, shape, backend, num_iterations=10)
+    elif backend == "tensorflow" and osf != 1:
+        pytest.skip("Tensorflow does not support OSF != 1")
+    else:
+        result = pipe(traj, shape, backend, osf=osf, num_iterations=10)
+
     distance = radial_distance(traj, shape)
-    result = pipe(traj, shape, backend, osf=osf, num_iterations=10)
     result = result / np.mean(result)
     distance = distance / np.mean(distance)
     if osf != 2:

--- a/tests/operators/test_density_for_op.py
+++ b/tests/operators/test_density_for_op.py
@@ -28,12 +28,9 @@ def radial_distance(traj, shape):
 @parametrize(backend=["gpunufft", "tensorflow"])
 def test_pipe(backend, traj, shape, osf):
     """Test the pipe method."""
-    if backend == "tensorflow" and osf == 1:
-        result = pipe(traj, shape, backend, num_iterations=10)
-    elif backend == "tensorflow" and osf != 1:
+    if backend == "tensorflow" and osf != 1:
         pytest.skip("Tensorflow does not support OSF != 1")
-    else:
-        result = pipe(traj, shape, backend, osf=osf, num_iterations=10)
+    result = pipe(traj, shape, backend, osf=osf, num_iterations=10)
 
     distance = radial_distance(traj, shape)
     result = result / np.mean(result)

--- a/tests/operators/test_density_for_op.py
+++ b/tests/operators/test_density_for_op.py
@@ -28,8 +28,8 @@ def radial_distance(traj, shape):
 @parametrize(backend=["gpunufft", "tensorflow"])
 def test_pipe(backend, traj, shape, osf):
     """Test the pipe method."""
-    if backend == "tensorflow" and osf != 1:
-        pytest.skip("Tensorflow does not support OSF != 1")
+    if backend == "tensorflow" and osf != 2:
+        pytest.skip("Tensorflow does not support OSF != 2")
     result = pipe(traj, shape, backend, osf=osf, num_iterations=10)
 
     distance = radial_distance(traj, shape)


### PR DESCRIPTION
- use compute_smaps instead of use_smap in the init of MRITensorflowNUFFT
- fix nm_iter into num_iterations in the pipe function 
- change syntaxe of pipe test because tensorflow mri  don't use osf (oversampling factor)