### PR TITLE
Clean CPU examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,7 @@ sphinx_gallery_conf = {
     "reference_url": {"mrinufft": None},
     "examples_dirs": ["../examples/"],
     "gallery_dirs": ["generated/autoexamples"],
+    "within_subsection_order": "ExampleTitleSortKey",
     "filename_pattern": "/example_",
     "ignore_pattern": r"(__init__|conftest|utils).py",
     "nested_sections": True,

--- a/examples/GPU/example_cg.py
+++ b/examples/GPU/example_cg.py
@@ -1,24 +1,27 @@
-# %%
 """
-Example of using the Conjugate Gradient method.
+======================================
+Reconstruction with conjugate gradient
+======================================
 
-This script demonstrates the use of the Conjugate Gradient (CG) method 
-for solving systems of linear equations of the form Ax = b, where A is a symmetric 
-positive-definite matrix. The CG method is an iterative algorithm that is particularly 
+An example to show how to reconstruct volumes using conjugate gradient method.
+
+This script demonstrates the use of the Conjugate Gradient (CG) method
+for solving systems of linear equations of the form Ax = b, where A is a symmetric
+positive-definite matrix. The CG method is an iterative algorithm that is particularly
 useful for large, sparse systems where direct methods are computationally expensive.
 
-The Conjugate Gradient method is widely used in various scientific and engineering 
-applications, including solving partial differential equations, optimization problems, 
+The Conjugate Gradient method is widely used in various scientific and engineering
+applications, including solving partial differential equations, optimization problems,
 and machine learning tasks.
 
 References
 ----------
-- Inpirations: 
+- Inpirations:
         - https://sigpy.readthedocs.io/en/latest/_modules/sigpy/alg.html#ConjugateGradient
         - https://aquaulb.github.io/book_solving_pde_mooc/solving_pde_mooc/notebooks/05_IterativeMethods/05_02_Conjugate_Gradient.html
-- Wikipedia: 
-        - https://en.wikipedia.org/wiki/Conjugate_gradient_method 
-        - https://en.wikipedia.org/wiki/Momentum 
+- Wikipedia:
+        - https://en.wikipedia.org/wiki/Conjugate_gradient_method
+        - https://en.wikipedia.org/wiki/Momentum
 """
 
 # %%
@@ -42,7 +45,10 @@ NufftOperator = mrinufft.get_operator("gpunufft")  # get the operator
 density = voronoi(samples_loc)  # get the density
 
 nufft = NufftOperator(
-    samples_loc, shape=image.shape, density=density, n_coils=1
+    samples_loc,
+    shape=image.shape,
+    density=density,
+    n_coils=1,
 )  # create the NUFFT operator
 
 # %%
@@ -52,17 +58,17 @@ reconstructed_image = cg(nufft, kspace_data)  # reconstruct the image
 
 # %%
 # Display the results
-plt.figure(figsize=(10, 5))
+plt.figure(figsize=(9, 3))
 plt.subplot(1, 3, 1)
-plt.title("Original Image")
+plt.title("Original image")
 plt.imshow(abs(image), cmap="gray")
 
 plt.subplot(1, 3, 2)
-plt.title("Reconstructed Image with CG")
+plt.title("Conjugate gradient")
 plt.imshow(abs(reconstructed_image), cmap="gray")
 
 plt.subplot(1, 3, 3)
-plt.title("Reconstructed Image with adjoint")
+plt.title("Adjoint NUFFT")
 plt.imshow(abs(nufft.adj_op(kspace_data)), cmap="gray")
 
 plt.show()

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -3,4 +3,4 @@
 Examples
 ========
 
-This is a collection of examples showing how to use mri-nufft to perform MR image reconstruction.
+This is a collection of examples showing how to use MRI-nufft to perform MR image reconstruction.

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -12,8 +12,8 @@ https://stackoverflow.com/questions/56807698/how-to-run-script-as-pytest-test
 
 """
 
-import sys
 import runpy
+import sys
 from pathlib import Path
 
 import matplotlib as mpl

--- a/examples/example_2D_trajectories.py
+++ b/examples/example_2D_trajectories.py
@@ -13,20 +13,16 @@ A collection of 2D non-Cartesian trajectories with analytical definitions.
 # are redundant across the different patterns, some of the documentation
 # will refer to previous patterns for explanation.
 #
-# Note that most sources have not been added yet, but will be in the near
-# future.
-#
 
 # External
 import matplotlib.pyplot as plt
 import numpy as np
+from utils import show_argument, show_trajectory
 
 # Internal
 import mrinufft as mn
 import mrinufft.trajectories.maths as mntm
 from mrinufft import display_2D_trajectory
-from utils import show_argument, show_trajectory
-
 
 # %%
 # Script options

--- a/examples/example_3D_trajectories.py
+++ b/examples/example_3D_trajectories.py
@@ -13,10 +13,10 @@ A collection of 3D non-Cartesian trajectories with analytical definitions.
 # are redundant across the different patterns, some of the documentation
 # will refer to previous patterns for explanation.
 #
-# Note that most sources have not been added yet, but will be in the near
-# future. Also the examples hereafter only cover natively 3D trajectories
+# Note that the examples hereafter only cover natively 3D trajectories
 # or famous 3D trajectories obtained from 2D. Examples on how to use
-# 2D-to-3D expansion methods will be presented over another page.
+# tools to make 3D trajectories out of 2D ones are presented in
+# :ref:`sphx_glr_generated_autoexamples_example_trajectory_tools.py`
 #
 # In this page in particular, we invite the user to manually run the script
 # to be able to manipulate the plot orientations with the matplotlib interface
@@ -26,12 +26,11 @@ A collection of 3D non-Cartesian trajectories with analytical definitions.
 # External
 import matplotlib.pyplot as plt
 import numpy as np
+from utils import show_argument, show_trajectory
 
 # Internal
 import mrinufft as mn
 from mrinufft import display_2D_trajectory, display_3D_trajectory
-from utils import show_argument, show_trajectory
-
 
 # %%
 # Script options

--- a/examples/example_display_config.py
+++ b/examples/example_display_config.py
@@ -3,19 +3,23 @@
 Trajectory display configuration
 ================================
 
-The look of the display trajectories can be tweaked by using :py:class:`displayConfig`
+An example to show how to customize trajectory displays.
 
-You can tune these parameters to your own taste and needs.
+The parameters presented here can be tuned to your own taste and needs
+by using :py:class:`displayConfig`.
 """
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
-# %%
 import numpy as np
 
 from mrinufft import display_2D_trajectory, display_3D_trajectory, displayConfig
 from mrinufft.trajectories import conify, initialize_2D_spiral
+
+# %%
+# Script options
+# ==============
+# These options are used in the examples below to define trajectories and display options.
 
 # Trajectory parameters
 Nc = 120  # Number of shots
@@ -25,7 +29,6 @@ Ns = 500  # Number of samples per shot
 figure_size = 10  # Figure size for trajectory plots
 subfigure_size = 6  # Figure size for subplots
 one_shot = -5  # Highlight one shot in particular
-
 
 # %%
 
@@ -47,28 +50,32 @@ def show_traj(traj, name, values, **kwargs):
 # %%
 #
 # Trajectory displays
-# ====================
-# To show case the display parameters of trajectories, we will use the following trajectory
-# The effect of trajectory parameter are explained in the :ref:`sphx_glr_generated_autoexamples_example_3D_trajectories.py` Example.
+# ===================
+#
+# The following trajectory will be used to showcase the display parameters.
+# The trajectory parameters are explained in the
+# :ref:`sphx_glr_generated_autoexamples_example_3D_trajectories.py` example.
 
 traj = conify(initialize_2D_spiral(Nc // 6, Ns), nb_cones=6)[::-1]
 
 # %%
 # ``linewidth``
 # -------------
-# The linewidth of the shot can be updated to have more or less empty space in the plot.
+# The ``linewidth`` corresponds to the curve thickness, and can be changed
+# to improve the shots visibility.
 show_traj(traj, "linewidth", [0.5, 2, 4])
 
 # %%
 # ``palette``
 # -----------
-# The ``palette`` parameter allows to change the color of the shots.
+# The ``palette`` parameter allows you to change the color of the shots.
 show_traj(traj, "palette", ["tab10", "magma", "jet"])
 
 # %%
 # ``one_shot_color``
 # ------------------
-# The ``one_shot_color`` parameter allows to highlight one shot in particular.
+# The ``one_shot_color`` parameter is used to highlight one shot in particular
+# with a specified color.
 with displayConfig(palette="viridis"):
     show_traj(
         traj, "one_shot_color", ["tab:blue", "tab:orange", "tab:green"], one_shot=-5
@@ -77,9 +84,10 @@ with displayConfig(palette="viridis"):
 # %%
 # ``nb_colors``
 # -------------
-# The ``nb_colors`` parameter allows to change the number of colors used to display the shots.
-
+# The ``nb_colors`` parameter allows you to change the number of colors used from the
+# specified color palette to display the shots.
 show_traj(traj, "nb_colors", [1, 4, 10])
+
 
 # %%
 # Labels, titles and legends
@@ -88,38 +96,25 @@ show_traj(traj, "nb_colors", [1, 4, 10])
 # %%
 # ``fontsize``
 # ------------
-# The ``fontsize`` parameter allows to change the fontsize of the labels /title
-
+# The ``fontsize`` parameter changes the fontsize of the labels/titles.
 show_traj(traj, "fontsize", [12, 18, 24])
 
 # %%
 # ``pointsize``
 # -------------
-# To show the gradient constraint violation we can use the ``pointsize`` parameter
+# The ``pointsize`` parameter is used when showing the gradient constraint violations
+# to change the violation point sizes.
 show_traj(traj, "pointsize", [0.5, 2, 4], show_constraints=True)
 
 # %%
 # ``gradient_point_color`` and ``slewrate_point_color``
 # -----------------------------------------------------
-# The ``gradient_point_color`` and ``slewrate_point_color`` parameters allows to change the color of the points
-# that are violating the gradient or slewrate constraints.
-
+# The ``gradient_point_color`` and ``slewrate_point_color`` parameters allows you
+# to change the color of the points where gradient or slew rate constraint violations
+# are observed.
 show_traj(
     traj,
     "slewrate_point_color",
     ["tab:blue", "tab:orange", "tab:red"],
     show_constraints=True,
 )
-
-
-# %%
-# Gradients profiles
-# ==================
-
-# %%
-
-# %%
-
-# %%
-
-# %%

--- a/examples/example_gif_2D.py
+++ b/examples/example_gif_2D.py
@@ -1,22 +1,26 @@
 """
-=======================
-2D Trajectories display
-=======================
+========================
+Animated 2D trajectories
+========================
 
-A collection of 2D trajectories are generated and saved as a gif.
+An animation to show 2D trajectory customization.
 
 """
+
+import time
 
 import joblib
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image, ImageSequence
-import time
+
 import mrinufft.trajectories.display as mtd
 import mrinufft.trajectories.trajectory2D as mtt
 from mrinufft.trajectories.display import displayConfig
 
-# Options
+# %%
+# Script options
+# ==============
 
 Nc = 16
 Ns = 200
@@ -29,7 +33,9 @@ nb_frames = 3
 duration = 150  # seconds
 
 
-# Generation
+# %%
+# Trajectory generation
+# =====================
 
 # Initialize trajectory function
 functions = [
@@ -124,6 +130,10 @@ arguments = [
     [None] * nb_frames,  # None
 ]
 
+
+# %%
+# Animation rendering
+# ===================
 
 frame_setup = [
     (f, i, name, arg)

--- a/examples/example_gif_2D.py
+++ b/examples/example_gif_2D.py
@@ -12,6 +12,7 @@ import time
 import joblib
 import matplotlib.pyplot as plt
 import numpy as np
+import tempfile as tmp
 from PIL import Image, ImageSequence
 
 import mrinufft.trajectories.display as mtd
@@ -142,7 +143,7 @@ frame_setup = [
 ]
 
 
-def draw_frame(func, index, name, arg, save_dir="/tmp/"):
+def draw_frame(func, index, name, arg):
     """Draw a single frame of the gif and save it to a tmp file."""
     trajectory = func(arg)
     # General configuration
@@ -168,8 +169,7 @@ def draw_frame(func, index, name, arg, save_dir="/tmp/"):
     )
 
     # Save figure
-    hashed = joblib.hash((index, name, arg, time.time()))
-    filename = save_dir + f"{hashed}.png"
+    filename = f"{tmp.NamedTemporaryFile().name}.png"
     plt.savefig(filename, bbox_inches="tight")
     plt.close()
     return filename

--- a/examples/example_gif_3D.py
+++ b/examples/example_gif_3D.py
@@ -12,6 +12,7 @@ import time
 import joblib
 import matplotlib.pyplot as plt
 import numpy as np
+import tempfile as tmp
 from PIL import Image, ImageSequence
 
 import mrinufft.trajectories.display as mtd
@@ -150,7 +151,7 @@ frame_setup = [
 ]
 
 
-def draw_frame(func, index, name, arg, save_dir="/tmp/"):
+def draw_frame(func, index, name, arg):
     """Draw a single frame of the gif and save it to a tmp file."""
     trajectory = func(arg)
     # General configuration
@@ -173,8 +174,7 @@ def draw_frame(func, index, name, arg, save_dir="/tmp/"):
     )
 
     # Save figure
-    hashed = joblib.hash((index, name, arg, time.time()))
-    filename = save_dir + f"{hashed}.png"
+    filename = f"{tmp.NamedTemporaryFile().name}.png"
     plt.savefig(filename, bbox_inches="tight")
     plt.close()
     return filename

--- a/examples/example_gif_3D.py
+++ b/examples/example_gif_3D.py
@@ -1,13 +1,14 @@
 """
-=======================
-3D Trajectories display
-=======================
+========================
+Animated 3D trajectories
+========================
 
-A collection of 3D trajectories are generated and saved as a gif.
+An animation to show 3D trajectory customization.
 
 """
 
 import time
+
 import joblib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,7 +18,9 @@ import mrinufft.trajectories.display as mtd
 import mrinufft.trajectories.trajectory3D as mtt
 from mrinufft.trajectories.display import displayConfig
 
-# Options
+# %%
+# Script options
+# ==============
 
 Nc = 8 * 8
 Ns = 200
@@ -30,7 +33,9 @@ nb_frames = 3
 duration = 150  # seconds
 
 
-# Generation
+# %%
+# Trajectory generation
+# =====================
 
 # Initialize trajectory function
 functions = [
@@ -133,6 +138,10 @@ arguments = [
     [None] * nb_frames,  # None
 ]
 
+
+# %%
+# Animation rendering
+# ===================
 
 frame_setup = [
     (f, i, name, arg)

--- a/examples/example_learn_samples_multires.py
+++ b/examples/example_learn_samples_multires.py
@@ -45,6 +45,7 @@ import brainweb_dl as bwdl
 import joblib
 import matplotlib.pyplot as plt
 import numpy as np
+import tempfile as tmp
 import torch
 from PIL import Image, ImageSequence
 from tqdm import tqdm
@@ -269,8 +270,7 @@ while model.current_decim >= 1:
                 for param in model.parameters():
                     param.clamp_(-0.5, 0.5)
             # Generate images for gif
-            hashed = joblib.hash((i, "learn_traj", time.time()))
-            filename = "/tmp/" + f"{hashed}.png"
+            filename = f"{tmp.NamedTemporaryFile().name}.png"
             plt.clf()
             fig, axs = plt.subplots(2, 2, figsize=(10, 10), num=1)
             plot_state(

--- a/examples/example_offresonance.py
+++ b/examples/example_offresonance.py
@@ -1,13 +1,13 @@
 """
-======================
-Off-resonance Corrected NUFFT Operator
-======================
+======================================
+Off-resonance corrected NUFFT operator
+======================================
 
-Example of Off-resonance Corrected NUFFT trajectory operator.
+An example to show how to setup an off-resonance corrected NUFFT operator.
 
-This examples show how to use the Off-resonance Corrected NUFFT operator to acquire 
-and reconstruct data in presence of field inhomogeneities.
-Here a spiral trajectory is used as a demonstration.
+This example shows how to use the off-resonance corrected (ORC) NUFFT operator
+to reconstruct data in presence of B0 field inhomogeneities.
+Hereafter a 2D spiral trajectory is used for demonstration.
 
 """
 
@@ -18,45 +18,70 @@ from mrinufft import display_2D_trajectory
 
 plt.rcParams["image.cmap"] = "gray"
 
+
 # %%
-# Data Generation
-# ===============
-# For realistic 2D image we will use a slice from the brainweb dataset.
-# installable using ``pip install brainweb-dl``
+# Data preparation
+# ================
+#
+# Image loading
+# -------------
+#
+# For realistic a 2D image we will use the BrainWeb dataset,
+# installable using ``pip install brainweb-dl``.
 
 from brainweb_dl import get_mri
 
 mri_data = get_mri(0, "T1")
-mri_data = mri_data[::-1, ...][90]
-plt.imshow(mri_data), plt.axis("off"), plt.title("ground truth")
+mri_data = np.flip(mri_data, axis=(0, 1, 2))[90]
 
 # %%
-# Masking
-# ===============
-# Here, we generate a binary mask to exclude the background.
-# We perform a simple binary threshold; in real-world application,
-# it is advised to use other tools (e.g., FSL-BET).
+
+plt.imshow(mri_data)
+plt.axis("off")
+plt.title("Groundtruth")
+plt.show()
+
+
+# %%
+# Mask generation
+# ---------------
+#
+# A binary mask is generated to exclude the background.
+# We use a simple binary threshold for this example, but for real-world application
+# it is advised to use more advanced methods and tools (e.g., FSL-BET).
 
 brain_mask = mri_data > 0.1 * mri_data.max()
-plt.imshow(brain_mask), plt.axis("off"), plt.title("brain mask")
 
 # %%
-# Field Generation
-# ===============
-# Here, we generate a radial B0 field with the same shape of
-# the input Shepp-Logan phantom
+
+plt.imshow(brain_mask)
+plt.axis("off")
+plt.title("brain mask")
+plt.show()
+
+
+# %%
+# B0 field map generation
+# -----------------------
+#
+# A dummy B0 field map is generated for this example using the input shape.
 
 from mrinufft.extras import make_b0map
 
-# generate field
 b0map, _ = make_b0map(mri_data.shape, b0range=(-200, 200), mask=brain_mask)
-plt.imshow(brain_mask * b0map, cmap="bwr", vmin=-200, vmax=200), plt.axis(
-    "off"
-), plt.colorbar(), plt.title("B0 map [Hz]")
 
 # %%
-# Generate a Spiral trajectory
-# ----------------------------
+
+plt.imshow(brain_mask * b0map, cmap="bwr", vmin=-200, vmax=200)
+plt.axis("off")
+plt.colorbar()
+plt.title("B0 map [Hz]")
+plt.show()
+
+
+# %%
+# Trajectory generation
+# ---------------------
 
 from mrinufft import initialize_2D_spiral
 from mrinufft.density import voronoi
@@ -67,44 +92,61 @@ t_read = np.arange(samples.shape[1]) * DEFAULT_RASTER_TIME * 1e-3
 t_read = np.repeat(t_read[None, ...], samples.shape[0], axis=0)
 density = voronoi(samples)
 
+# %%
+
 display_2D_trajectory(samples)
+plt.show()
 
 # %%
-# Setup the Operator
-# ==================
+# Operator setup
+# ==============
 
 from mrinufft import get_operator
 from mrinufft.operators.off_resonance import MRIFourierCorrected
 
 # Generate standard NUFFT operator
 nufft = get_operator("finufft")(
-    samples=samples,
+    samples=2 * np.pi * samples,  # normalize for finufft
     shape=mri_data.shape,
     density=density,
 )
 
-# Generate Fourier Corrected operator
-mfi_nufft = MRIFourierCorrected(
+# Generate NUFFT off-resonance corrected operator
+orc_nufft = MRIFourierCorrected(
     nufft, b0_map=b0map, readout_time=t_read, mask=brain_mask
 )
 
-# Generate K-Space
-kspace = mfi_nufft.op(mri_data)
+# Generate k-space
+kspace_on = nufft.op(mri_data)
+kspace_off = orc_nufft.op(mri_data)
 
-# Reconstruct without field correction
-mri_data_adj = nufft.adj_op(kspace)
+# Reconstruct without B0 field inhomogeneity
+mri_data_adj_ref = nufft.adj_op(kspace_on)
+mri_data_adj_ref = np.squeeze(abs(mri_data_adj_ref))
+
+# Reconstruct without B0 field correction
+mri_data_adj = nufft.adj_op(kspace_off)
 mri_data_adj = np.squeeze(abs(mri_data_adj))
 
-# Reconstruct with field correction
-mri_data_adj_mfi = mfi_nufft.adj_op(kspace)
-mri_data_adj_mfi = np.squeeze(abs(mri_data_adj_mfi))
-
-fig2, ax2 = plt.subplots(1, 2)
-ax2[0].imshow(mri_data_adj), ax2[0].axis("off"), ax2[0].set_title("w/o correction")
-ax2[1].imshow(mri_data_adj_mfi), ax2[1].axis("off"), ax2[1].set_title("with correction")
-
-plt.show()
+# Reconstruct with B0 field correction
+mri_data_adj_orc = orc_nufft.adj_op(kspace_off)
+mri_data_adj_orc = np.squeeze(abs(mri_data_adj_orc))
 
 # %%
-# The blurring is significantly reduced using the Off-resonance Corrected
-# operator (right)
+# The blurring observed in the presence of B0 field inhomogeneities (middle)
+# is significantly reduced using the off-resonance corrected NUFFT operator (right).
+
+fig2, ax2 = plt.subplots(1, 3, figsize=(9, 3))
+# No off-resonance
+ax2[0].imshow(mri_data_adj_ref)
+ax2[0].axis("off")
+ax2[0].set_title("No off-resonance")
+# No off-resonance correction
+ax2[1].imshow(mri_data_adj)
+ax2[1].axis("off")
+ax2[1].set_title("Off-resonance")
+# Off-resonance corrected
+ax2[2].imshow(mri_data_adj_orc)
+ax2[2].axis("off")
+ax2[2].set_title("Corrected off-resonance")
+plt.show()

--- a/examples/example_readme.py
+++ b/examples/example_readme.py
@@ -1,8 +1,8 @@
 """
-Minimal Example script
+Minimal example script
 ======================
 
-This script shows how to use the package to perform a simple NUFFT.
+An example to show how to perform a simple NUFFT.
 """
 
 import matplotlib.pyplot as plt
@@ -13,7 +13,7 @@ import mrinufft
 from mrinufft.density import voronoi
 from mrinufft.trajectories import display
 
-# Create a 2D Radial trajectory for demo
+# Create a 2D radial trajectory for demo
 samples_loc = mrinufft.initialize_2D_radial(Nc=100, Ns=500)
 # Get a 2D image for the demo (512x512)
 image = np.complex64(face(gray=True)[256:768, 256:768])
@@ -25,27 +25,32 @@ NufftOperator = mrinufft.get_operator("finufft")
 # For better image quality we use a density compensation
 density = voronoi(samples_loc)
 
-# And create the associated operator.
+# And create the associated operator
 nufft = NufftOperator(
     samples_loc, shape=image.shape, density=density, n_coils=1, squeeze_dims=True
 )
 
-kspace_data = nufft.op(image)  # Image -> Kspace
-image2 = nufft.adj_op(kspace_data)  # Kspace -> Image
+kspace_data = nufft.op(image)  # Image -> K-space
+image2 = nufft.adj_op(kspace_data)  # K-space -> Image
+
+# %%
 
 # Show the results
 fig, ax = plt.subplots(2, 2)
 ax = ax.flatten()
-
+# Upper left reference image
 ax[0].imshow(abs(image), cmap="gray")
 ax[0].axis("off")
 ax[0].set_title("original image")
+# Upper right trajectory
 display.display_2D_trajectory(samples_loc, subfigure=ax[1])
 ax[1].set_aspect("equal")
 ax[1].set_title("Sampled points in k-space")
+# Bottom left reconstructed image
 ax[2].imshow(abs(image2), cmap="gray")
 ax[2].axis("off")
 ax[2].set_title("Auto adjoint image")
+# Bottom right error
 ax[3].imshow(
     abs(image2) / np.max(abs(image2)) - abs(image) / np.max(abs(image)), cmap="gray"
 )
@@ -57,7 +62,7 @@ plt.show()
 
 # %%
 # .. note::
-#    This image is not the same as the original one because the NUFFT operator
-#    is not a perfect adjoint, and we undersampled by a factor of 5.
-#    The artefact of reconstruction can be remove by using an iterative reconstruction method.
+#    This resulting image is not the same as the original one because the NUFFT operator
+#    is not a perfect inverse operation but an adjoint, and we undersampled by a factor of 5.
+#    The reconstruction artifacts can be removed by using an iterative reconstruction method.
 #    Check PySAP-mri documentation for examples.

--- a/examples/example_stacked.py
+++ b/examples/example_stacked.py
@@ -1,13 +1,13 @@
 """
 ======================
-Stacked NUFFT Operator
+Stacked NUFFT operator
 ======================
 
-Example of Stacked NUFFT trajectory operator.
+An example to show how to setup a stacked NUFFT operator.
 
-This examples show how to use the Stacked NUFFT operator to acquire and reconstruct data
-in kspace where the sampling of pattern is a stack of non cartesian trajectory.
-Here a stack of spiral is used as a demonstration.
+This example shows how to use the stacked NUFFT operator to reconstruct data
+when the sampling pattern in k-space is a stack of 2D non-Cartesian trajectories.
+Hereafter a stack of 2D spirals is used for demonstration.
 
 """
 
@@ -18,43 +18,61 @@ from mrinufft import display_2D_trajectory
 
 plt.rcParams["image.cmap"] = "gray"
 
+
 # %%
-# Data Generation
-# ===============
-# For realistic 3D images we will use the brainweb dataset.
-# installable using ``pip install brainweb-dl``
+# Data preparation
+# ================
+#
+# Image loading
+# -------------
+#
+# For realistic 3D images we will use the BrainWeb dataset,
+# installable using ``pip install brainweb-dl``.
 
 from brainweb_dl import get_mri
 
 mri_data = get_mri(0, "T1")
-mri_data = mri_data[::-1, ...]
-fig, ax = plt.subplots(1, 3)
+mri_data = np.flip(mri_data, axis=(0, 1, 2))
+
+# %%
+
+fig, ax = plt.subplots(1, 3, figsize=(10, 3))
 ax[0].imshow(mri_data[90, :, :])
 ax[1].imshow(mri_data[:, 108, :])
 ax[2].imshow(mri_data[:, :, 90])
+plt.show()
+
 
 # %%
-# Generate a Spiral trajectory
-# ----------------------------
+# Trajectory generation
+# ---------------------
+#
+# Only the 2D pattern needs to be initialized, along with
+# its density to improve the adjoint NUFFT operation and
+# the location of the different slices.
+#
 
 from mrinufft import initialize_2D_spiral
 from mrinufft.density import voronoi
 
 samples = initialize_2D_spiral(Nc=16, Ns=500, nb_revolutions=10)
 density = voronoi(samples)
-
-display_2D_trajectory(samples)
-# specify locations for the stack of trajectories.
-kz_slices = np.arange(mri_data.shape[-1])
+kz_slices = np.arange(mri_data.shape[-1])  # Specify locations for the stacks.
 
 # %%
-# Setup the Operator
-# ==================
+
+display_2D_trajectory(samples)
+plt.show()
+
+
+# %%
+# Operator setup
+# ==============
 
 from mrinufft.operators.stacked import MRIStackedNUFFT
 
 stacked_nufft = MRIStackedNUFFT(
-    samples=samples,
+    samples=2 * np.pi * samples,  # normalize for finufft
     shape=mri_data.shape,
     z_index=kz_slices,
     backend="finufft",
@@ -64,15 +82,16 @@ stacked_nufft = MRIStackedNUFFT(
 )
 
 kspace_stack = stacked_nufft.op(mri_data)
-print(kspace_stack.shape)
+print(f"K-space shape: {kspace_stack.shape}")
 
 mri_data_adj = stacked_nufft.adj_op(kspace_stack)
 mri_data_adj = np.squeeze(abs(mri_data_adj))
-print(mri_data_adj.shape)
+print(f"Volume shape: {mri_data_adj.shape}")
 
-fig2, ax2 = plt.subplots(1, 3)
+# %%
+
+fig2, ax2 = plt.subplots(1, 3, figsize=(10, 3))
 ax2[0].imshow(mri_data_adj[90, :, :])
 ax2[1].imshow(mri_data_adj[:, 108, :])
 ax2[2].imshow(mri_data_adj[:, :, 90])
-
 plt.show()

--- a/examples/example_trajectory_tools.py
+++ b/examples/example_trajectory_tools.py
@@ -24,14 +24,12 @@ A collection of tools to manipulate and develop non-Cartesian trajectories.
 # External
 import matplotlib.pyplot as plt
 import numpy as np
+from utils import show_argument, show_trajectory
 
 # Internal
 import mrinufft as mn
 import mrinufft.trajectories.tools as tools
-
 from mrinufft.trajectories.utils import KMAX
-from utils import show_argument, show_trajectory
-
 
 # %%
 # Script options

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -3,12 +3,13 @@ This module contains visualisation functions only relevant to
 the examples.
 """
 
-# External imports
-import numpy as np
 import matplotlib.pyplot as plt
 
+# External imports
+import numpy as np
+
 # Internal imports
-from mrinufft import displayConfig, display_2D_trajectory, display_3D_trajectory
+from mrinufft import display_2D_trajectory, display_3D_trajectory, displayConfig
 
 
 def show_argument(function, arguments, one_shot, subfig_size, dim="3D", axes=(0, 1)):


### PR DESCRIPTION
This PR cleans the CPU examples in several ways:
- Change brain orientations to the medical standard
- Reduce blank spaces around images
- Remove some overlaps in figures
- Split script-specific code from the utils and data preparation
- Homogeneize parts and subparts names & structures
- Homogeneize one-line descriptions
- Homogeneize capitalizations, punctuations
- Apply isort to clean imports
- Fix a bunch of typos
- Fix paragraph irregularities
- Fix a few cross references
- Break lines sometimes
- Remove a few dead parts
- Remove many useless outputs
- Remove references to MFI in off-resonance operator (we don't do MFI but the opposite)

I will try to do the same for GPU examples later. Note that trajectory examples are barely touched, not because they are perfect but the opposite as I plan to break them into smaller examples as discussed in #118.