### PR TITLE
Add arc length parameterization

### DIFF
--- a/src/mrinufft/trajectories/__init__.py
+++ b/src/mrinufft/trajectories/__init__.py
@@ -8,6 +8,7 @@ from .inits import (
     initialize_3D_random_walk,
     initialize_3D_travelling_salesman,
 )
+from .projection import fit_arc_length
 from .sampling import (
     create_chauffert_density,
     create_cutoff_decay_density,
@@ -19,12 +20,14 @@ from .sampling import (
 from .tools import (
     conify,
     duplicate_along_axes,
+    get_random_loc_1d,
     oversample,
     precess,
     radialize_center,
     rotate,
     shellify,
     stack,
+    stack_random,
     stack_spherically,
 )
 from .trajectory2D import (
@@ -55,12 +58,6 @@ from .trajectory3D import (
     initialize_3D_wave_caipi,
     initialize_3D_wong_radial,
 )
-
-from .tools import (
-    stack_random,
-    get_random_loc_1d,
-)
-
 
 __all__ = [
     # trajectories
@@ -120,4 +117,6 @@ __all__ = [
     "displayConfig",
     "display_2D_trajectory",
     "display_3D_trajectory",
+    # projection
+    "fit_arc_length",
 ]

--- a/src/mrinufft/trajectories/projection.py
+++ b/src/mrinufft/trajectories/projection.py
@@ -1,0 +1,58 @@
+"""Functions to fit gradient constraints."""
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.interpolate import CubicSpline
+
+
+def fit_arc_length(
+    trajectory: NDArray, order: int | None = None, eps: float = 1e-8
+) -> NDArray:
+    """Adjust the trajectory to have a uniform arc-length distribution.
+
+    The trajectory is parametrized according to its arc length along a
+    cubic-interpolated path and samples are repositioned to minimize
+    the gradients amplitude. This solution is optimal with respect to
+    gradients but can lead to excessive slew rates, and it will change
+    the overall density.
+
+    Parameters
+    ----------
+    trajectory: NDArray
+        A 2D or 3D trajectory of shape (Nc, Ns, Nd), with Nc the number of shots,
+        Ns the number of samples per shot, and Nd the number of dimensions.
+    order: int | None
+        The order of the norm used to compute arc length, based on the convention from
+        `numpy.linalg.norm`. Defaults to None (Euclidean norm).
+    eps: float
+        Convergence threshold for stopping the iterative refinement. Defaults to 1e-8.
+
+    Returns
+    -------
+    NDArray: The reparameterized trajectory with the same shape as the input.
+    """
+    Nc, Ns, Nd = trajectory.shape
+    new_trajectory = np.copy(trajectory)
+
+    for i in range(Nc):
+        time = np.linspace(0, 1, Ns)
+        projection = trajectory[i]
+        old_projection = 0
+        arc_func = CubicSpline(time, projection)
+
+        while (
+            np.linalg.norm(projection - old_projection) / np.linalg.norm(projection)
+            > eps
+        ):
+            arc_length = np.cumsum(
+                np.linalg.norm(np.diff(projection, axis=0), ord=order, axis=-1), axis=0
+            )
+            arc_length = np.concatenate([[0], arc_length])
+            arc_length = arc_length / arc_length[-1]
+            inv_arc_func = CubicSpline(arc_length, time)
+
+            time = inv_arc_func(np.linspace(0, 1, Ns))
+            old_projection = np.copy(projection)
+            projection = arc_func(time)
+        new_trajectory[i] = projection
+    return new_trajectory

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -8,7 +8,7 @@ from scipy.interpolate import CubicSpline, interp1d
 from scipy.stats import norm
 
 from .maths import Rv, Rx, Ry, Rz
-from .utils import KMAX, initialize_tilt, VDSpdf, VDSorder
+from .utils import KMAX, VDSorder, VDSpdf, initialize_tilt
 
 ################
 # DIRECT TOOLS #

--- a/src/mrinufft/trajectories/trajectory3D.py
+++ b/src/mrinufft/trajectories/trajectory3D.py
@@ -17,6 +17,7 @@ from .maths import (
     Rz,
     generate_fibonacci_circle,
 )
+from .projection import fit_arc_length
 from .tools import conify, duplicate_along_axes, epify, precess, stack
 from .trajectory2D import initialize_2D_radial, initialize_2D_spiral
 from .utils import KMAX, Packings, Spirals, initialize_shape_norm, initialize_tilt
@@ -728,6 +729,9 @@ def initialize_3D_annular_shells(
     """Initialize 3D trajectories with annular shells.
 
     An exclusive trajectory inspired from the work proposed in [HM11]_.
+    It is similar to other trajectories based on concentric rings but
+    rings are split and recombined by pairs to better balance
+    the shot lengths.
 
     Parameters
     ----------
@@ -832,6 +836,8 @@ def initialize_3D_annular_shells(
         trajectory[count : count + Ms] = shell
         count += Ms
 
+    # Balance the samples over the recombined shots
+    trajectory = fit_arc_length(trajectory)
     return KMAX * trajectory
 
 


### PR DESCRIPTION
This PR adds a tool to minimize the gradient amplitudes using arc length parameterization. It makes the samples evenly distributed along the path of each shot while maintaining the full shot length, and therefore the maximum gradient amplitude is optimally minimized as all gradient strengths are the same (but not the gradient directions of course). The catch is that the maximum slew rate can become insanely high if the path is not smooth enough. An example is shown below.

![Screenshot from 2025-02-15 00-41-06](https://github.com/user-attachments/assets/c51abf63-45e5-4ef2-828f-abadbf147c8a)
(A) A classic (blue) spiral trajectory is projected (orange) to be uniformly distributed over the spiral path. (B) shows the gradient amplitudes and (C) shows the slew rates. The projected gradient strength is completely flat but it leads to much stronger slew rates around the center where the spiral direction changes.