### PR TITLE
Clean signal gradient display

### DIFF
--- a/src/mrinufft/trajectories/__init__.py
+++ b/src/mrinufft/trajectories/__init__.py
@@ -19,12 +19,14 @@ from .sampling import (
 from .tools import (
     conify,
     duplicate_along_axes,
+    get_random_loc_1d,
     oversample,
     precess,
     radialize_center,
     rotate,
     shellify,
     stack,
+    stack_random,
     stack_spherically,
 )
 from .trajectory2D import (
@@ -55,12 +57,6 @@ from .trajectory3D import (
     initialize_3D_wave_caipi,
     initialize_3D_wong_radial,
 )
-
-from .tools import (
-    stack_random,
-    get_random_loc_1d,
-)
-
 
 __all__ = [
     # trajectories

--- a/src/mrinufft/trajectories/display.py
+++ b/src/mrinufft/trajectories/display.py
@@ -515,12 +515,12 @@ def display_gradients_simply(
 
     # Show signal as modulated distance to center
     distances = np.linalg.norm(trajectory[shot_ids, 1:-1], axis=-1)
-    distances = np.tile(distances.reshape((len(shot_ids), -1, 1)), (1, 1, 10))
+    distances = distances / np.max(distances)
     signal = 1 - distances.reshape((len(shot_ids), -1)) / np.max(distances)
     signal = (
-        signal * np.exp(2j * np.pi * figsize / 100 * np.arange(signal.shape[1]))
-    ).real
-    signal = signal * np.abs(signal) ** 3
+        signal**2
+        * np.cos(figsize * 8 * 2 * np.pi * np.linspace(0, 1, signal.shape[-1]))[None, :]
+    )
 
     colors = displayConfig.get_colorlist()
     # Show signal for each requested shot

--- a/src/mrinufft/trajectories/display3D.py
+++ b/src/mrinufft/trajectories/display3D.py
@@ -1,14 +1,15 @@
 """Utils for displaying 3D trajectories."""
 
-from mrinufft import get_operator, get_density
-from mrinufft.trajectories.utils import (
-    convert_trajectory_to_gradients,
-    convert_gradients_to_slew_rates,
-    KMAX,
-    DEFAULT_RASTER_TIME,
-)
-from mrinufft.density.utils import flat_traj
 import numpy as np
+
+from mrinufft import get_density, get_operator
+from mrinufft.density.utils import flat_traj
+from mrinufft.trajectories.utils import (
+    DEFAULT_RASTER_TIME,
+    KMAX,
+    convert_gradients_to_slew_rates,
+    convert_trajectory_to_gradients,
+)
 
 
 def get_gridded_trajectory(

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -8,7 +8,7 @@ from scipy.interpolate import CubicSpline, interp1d
 from scipy.stats import norm
 
 from .maths import Rv, Rx, Ry, Rz
-from .utils import KMAX, initialize_tilt, VDSpdf, VDSorder
+from .utils import KMAX, VDSorder, VDSpdf, initialize_tilt
 
 ################
 # DIRECT TOOLS #


### PR DESCRIPTION
Minor PR to fix the "signal" display for gradient diagrams, that was needlessly complex and not even properly representing signal as intended.

Old display
![01](https://github.com/user-attachments/assets/a2d976fb-dd80-4011-97a7-337f7774072b)

New display
![02](https://github.com/user-attachments/assets/b009c870-cb42-43b4-844d-cec6425a13c4)
