### PR TITLE
 Fix : add negate flag to switch sign convention in ORC

### DIFF
--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -199,7 +199,7 @@ class MRIFourierCorrected(FourierOperatorBase):
         The default is ``None`` (purely imaginary field).
         Also supports Cupy arrays and Torch tensors.
     isign : int, optional
-        Sign convention for spatial phase. 
+        Sign convention for spatial phase.
         Either `-1` (default, e^{-iωt}) or `1` (e^{iωt}).
     backend: str, optional
         The backend to use for computations. Either 'cpu', 'gpu' or 'torch'.

--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -269,8 +269,7 @@ class MRIFourierCorrected(FourierOperatorBase):
                 r2star_map,
             )
         if self.B is None or self.tl is None:
-            raise ValueError(
-                "Please either provide fieldmap and t or B and tl")
+            raise ValueError("Please either provide fieldmap and t or B and tl")
         self.n_interpolators = self.B.shape[0]
 
         # create spatial interpolator
@@ -279,8 +278,7 @@ class MRIFourierCorrected(FourierOperatorBase):
             self.C = None
             self.field_map = field_map
         else:
-            self.C = _get_spatial_coefficients(
-                field_map, self.tl, isign=self.isign)
+            self.C = _get_spatial_coefficients(field_map, self.tl, isign=self.isign)
             self.field_map = None
 
     def op(self, data, *args):
@@ -303,8 +301,7 @@ class MRIFourierCorrected(FourierOperatorBase):
         data_d = self.xp.asarray(data)
         if self.C is not None:
             for idx in range(self.n_interpolators):
-                y += self.B[idx] * \
-                    self._fourier_op.op(self.C[idx] * data_d, *args)
+                y += self.B[idx] * self._fourier_op.op(self.C[idx] * data_d, *args)
         else:
             for idx in range(self.n_interpolators):
                 C = self.xp.exp(-self.field_map * self.tl[idx].item())
@@ -388,7 +385,7 @@ def _get_spatial_coefficients(field_map, tl, isign=-1):
     if isign not in (-1, 1):
         raise ValueError("isign must be -1 or 1.")
     # get spatial coeffs
-    C = xp.exp(isign * field_map[..., None])
+    C = xp.exp(isign * tl * field_map[..., None])
     C = C[None, ...].swapaxes(0, -1)[
         ..., 0
     ]  # (..., n_time_segments) -> (n_time_segments, ...)

--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -199,7 +199,8 @@ class MRIFourierCorrected(FourierOperatorBase):
         The default is ``None`` (purely imaginary field).
         Also supports Cupy arrays and Torch tensors.
     isign : int, optional
-        Sign convention for spatial phase. Either `-1` (default, e^{-iωt}) or `1` (e^{iωt}).
+        Sign convention for spatial phase. 
+        Either `-1` (default, e^{-iωt}) or `1` (e^{iωt}).
     backend: str, optional
         The backend to use for computations. Either 'cpu', 'gpu' or 'torch'.
         The default is `cpu`.
@@ -269,7 +270,8 @@ class MRIFourierCorrected(FourierOperatorBase):
                 r2star_map,
             )
         if self.B is None or self.tl is None:
-            raise ValueError("Please either provide fieldmap and t or B and tl")
+            raise ValueError(
+                "Please either provide fieldmap and t or B and tl")
         self.n_interpolators = self.B.shape[0]
 
         # create spatial interpolator
@@ -278,7 +280,8 @@ class MRIFourierCorrected(FourierOperatorBase):
             self.C = None
             self.field_map = field_map
         else:
-            self.C = _get_spatial_coefficients(field_map, self.tl, isign=self.isign)
+            self.C = _get_spatial_coefficients(
+                field_map, self.tl, isign=self.isign)
             self.field_map = None
 
     def op(self, data, *args):
@@ -301,7 +304,8 @@ class MRIFourierCorrected(FourierOperatorBase):
         data_d = self.xp.asarray(data)
         if self.C is not None:
             for idx in range(self.n_interpolators):
-                y += self.B[idx] * self._fourier_op.op(self.C[idx] * data_d, *args)
+                y += self.B[idx] * \
+                    self._fourier_op.op(self.C[idx] * data_d, *args)
         else:
             for idx in range(self.n_interpolators):
                 C = self.xp.exp(-self.field_map * self.tl[idx].item())

--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -270,8 +270,7 @@ class MRIFourierCorrected(FourierOperatorBase):
                 r2star_map,
             )
         if self.B is None or self.tl is None:
-            raise ValueError(
-                "Please either provide fieldmap and t or B and tl")
+            raise ValueError("Please either provide fieldmap and t or B and tl")
         self.n_interpolators = self.B.shape[0]
 
         # create spatial interpolator
@@ -280,8 +279,7 @@ class MRIFourierCorrected(FourierOperatorBase):
             self.C = None
             self.field_map = field_map
         else:
-            self.C = _get_spatial_coefficients(
-                field_map, self.tl, isign=self.isign)
+            self.C = _get_spatial_coefficients(field_map, self.tl, isign=self.isign)
             self.field_map = None
 
     def op(self, data, *args):
@@ -304,8 +302,7 @@ class MRIFourierCorrected(FourierOperatorBase):
         data_d = self.xp.asarray(data)
         if self.C is not None:
             for idx in range(self.n_interpolators):
-                y += self.B[idx] * \
-                    self._fourier_op.op(self.C[idx] * data_d, *args)
+                y += self.B[idx] * self._fourier_op.op(self.C[idx] * data_d, *args)
         else:
             for idx in range(self.n_interpolators):
                 C = self.xp.exp(-self.field_map * self.tl[idx].item())

--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -199,7 +199,8 @@ class MRIFourierCorrected(FourierOperatorBase):
         The default is ``None`` (purely imaginary field).
         Also supports Cupy arrays and Torch tensors.
     negate: bool, optional, default=False
-        If True, negate the field map. Useful for matching the convention of your field map generation.
+        If True, negate the field map. Useful for matching the convention of
+        your field map generation.
     backend: str, optional
         The backend to use for computations. Either 'cpu', 'gpu' or 'torch'.
         The default is `cpu`.


### PR DESCRIPTION
This PR adds a negate flag to allow switching the sign of the field map in off-resonance correction, addressing issue [#254](https://github.com/mind-inria/mri-nufft/issues/254).

Default remains backward-compatible (negate=True)

If negate=False, the phase factor uses a + sign (conventional)