### PR TITLE
adding the fix to gradient slewrate (#264)

### DIFF
--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -350,7 +350,9 @@ def convert_gradients_to_slew_rates(
         Gradients at the beginning of the readout window.
     """
     # Compute slew rates and starting gradients
-    slewrates = np.diff(gradients, axis=1) / raster_time
+    slewrates = np.zeros_like(gradients)
+    slewrates[:, 0] = gradients[:, 0] / raster_time
+    slewrates[:, 1:] = np.diff(gradients, axis=1) / raster_time
     initial_gradients = gradients[:, 0, :]
     return slewrates, initial_gradients
 


### PR DESCRIPTION
fixes a bug in the convert_gradients_to_slew_rates function where the initial slew rate was implicitly omitted or zeroed. This ensures correct handling of the initial transition from G = 0 to G = G₀