### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: 🐛 Bug
+about: Report a problem
+labels: 'bug'
+---
+
+### Problem
+
+> A report of the problem you observed.
+
+### Expectation
+
+> A description of what you would were expecting to observe instead.
+
+### Suggestion
+
+> Some ideas about how to solve that problem.
+
+### Reproducibility
+
+> Steps to reproduce your observations so we can see the problem too, ideally some minimal code example.
+
+### Additional context
+
+> More context about your project, operating system, hardware or whatever to better understand the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: 💡 Feature
+about: Suggest an idea
+labels: 'feature'
+---
+
+### Problem
+
+> A description of the situation you would like to solve.
+
+### Requested feature
+
+> An explanation of the solution/feature you would like to see implemented and how it solves the problem.
+
+### Additional context
+
+> Some context about your project to better understand long-term implications of the requested feature.


### PR DESCRIPTION
This MR is a proposition to add issue templates with some basic questions to help make issues more structured, descriptive, and overall easier to understand.

Feel free to make suggestions about the format, or adding more etc. We could also have a template for the merge requests.