### PR TITLE
Pulseq

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,7 @@ jobs:
           ${{ env.create_venv }}
           ${{ env.activate_venv }}
           python -m pip install --upgrade pip
-          python -m pip install .[doc,finufft,autodiff,gpunufft,cufinufft,sigpy,extra] fastmri
+          python -m pip install .[doc,finufft,autodiff,gpunufft,cufinufft,sigpy,extra,io] fastmri
 
       - name: Build API documentation
         run: |

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -219,17 +219,10 @@ jobs:
         run: |
           ${{ env.create_venv }}
           ${{ env.activate_venv }}
-          python -m pip install --upgrade pip
-          python -m pip install -e .[extra,test,dev]
-          python -m pip install pooch brainweb-dl torch fastmri
-
-      - name: Install Python deps
-        shell: bash
-        run: |
-          ${{ env.activate_venv }}
           ${{ env.setup_cuda }}
           python -m pip install --upgrade pip
-          python -m pip install -e .[test,dev,finufft,cufinufft,gpuNUFFT,sigpy,extra,autodiff,doc]
+          python -m pip install pooch brainweb-dl torch fastmri
+          python -m pip install -e .[test,dev,finufft,cufinufft,gpuNUFFT,sigpy,extra,autodiff,doc,io]
         
       - name: Run examples
         shell: bash

--- a/examples/trajectories/example_grad_connection.py
+++ b/examples/trajectories/example_grad_connection.py
@@ -79,6 +79,9 @@ for method in ["lp", "lp-minslew", "osqp"]:
 # %%
 # Show the results
 # ==================
+#
+# Setup the figure
+
 
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
@@ -93,6 +96,8 @@ gstraj = gridspec.GridSpecFromSubplotSpec(1, 3, subplot_spec=gs0[1])
 grad_ax = gsgrad.subplots(sharex=True)
 axs = gstraj.subplots(sharex=True, sharey=True)
 time = np.arange(full_grads["lp"].shape[1]) * acq.raster_time  # in ms
+
+# %%
 # Plot gradients
 
 for method in ["lp", "lp-minslew", "osqp"]:
@@ -125,6 +130,8 @@ grad_ax[1].axvline(
 
 grad_ax[0].legend(loc="upper center")
 
+
+# Plot trajectories
 
 for i, method in enumerate(["lp", "lp-minslew", "osqp"]):
     t = full_traj[method]

--- a/examples/trajectories/example_grad_connection.py
+++ b/examples/trajectories/example_grad_connection.py
@@ -1,0 +1,162 @@
+# %%
+"""
+===========================================
+Prephasors, Spoilers and arbitrary Waveforms
+============================================
+
+
+This example showcases how to create gradient waveform under a set of constraints. 
+
+
+When designing MRI sequences It's often necessary to have some way of going from
+a point A to point B in the kspace. For instance:
+
+- At the beginning of an
+acquisition we may want to go from the center of the k-space to the starting
+point of the trajectory. This is usually call the "prephasor" or "prewinder"
+gradient.
+- At the end of an acquisition we may want to go from the end point of
+the trajectory back to the center, or to crush any residual magnetization by
+going to the edge of the k-space. This is usually called a "rewind" or "spoiler"
+gradient.
+
+However, these gradient waveforms needs to be designed under the hardware system constraints:
+The maximum gradient strength :math:`g_\max`, and slew rate :math:`s_\max`, and the raster time :math:`\Delta t`.
+
+Once the constraints are defined, the gradient waveforms can be determined using different methods
+such as linear programming or quadratic programming.
+
+This example shows how to create such gradient waveforms using MRI-NUFFT.
+"""
+
+# %%
+import numpy as np
+
+from mrinufft import initialize_2D_cones
+from mrinufft.trajectories.utils import (
+    Acquisition,
+    convert_gradients_to_trajectory,
+    convert_trajectory_to_gradients,
+)
+from mrinufft.trajectories.gradients import (
+    connect_gradient,
+    get_prephasors_and_spoilers,
+)
+
+# %%
+# We are going to rely on the :py:obj:`Acquisition` configuration to define the constraints
+
+acq = Acquisition.default
+
+# %%
+# Create a demo radial trajectory
+
+traj = initialize_2D_cones(Nc=32, Ns=512, tilt="uniform", in_out=True)
+
+traj_grad, init_points = convert_trajectory_to_gradients(traj, acq)
+
+
+# Create prephasor and spoiler gradients
+# =======================================
+
+prephasors = {}
+spoilers = {}
+full_grads = {}
+full_traj = {}
+for method in ["lp", "lp-minslew", "osqp"]:
+    print(f"Creating prephasor and spoiler gradients using method: {method}")
+    p, s = get_prephasors_and_spoilers(
+        traj, acq=acq, method=method, spoil_loc=(1, 0, 0)
+    )
+    g = np.concatenate([p, traj_grad, s], axis=1)
+
+    prephasors[method] = p
+    spoilers[method] = s
+    # Connect the prephasor and spoiler gradients to the trajectory gradients
+    full_grads[method] = g
+    full_traj[method] = convert_gradients_to_trajectory(
+        g, np.zeros_like(init_points), acq=acq
+    )
+
+
+# %%
+# Show the results
+# ==================
+
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+
+fig = plt.figure(figsize=(21, 7))
+gs0 = fig.add_gridspec(2, 1, hspace=0.3)
+
+gsgrad = gridspec.GridSpecFromSubplotSpec(2, 1, subplot_spec=gs0[0])
+gstraj = gridspec.GridSpecFromSubplotSpec(1, 3, subplot_spec=gs0[1])
+
+
+grad_ax = gsgrad.subplots(sharex=True)
+axs = gstraj.subplots(sharex=True, sharey=True)
+time = np.arange(full_grads["lp"].shape[1]) * acq.raster_time  # in ms
+# Plot gradients
+
+for method in ["lp", "lp-minslew", "osqp"]:
+    grad_ax[0].plot(
+        np.arange(full_grads[method].shape[1]) * acq.raster_time,
+        full_grads[method][0, :, 0],  # show x gradient
+        label=f"{method}",
+    )
+    grad_ax[1].plot(
+        np.arange(full_grads[method].shape[1]) * acq.raster_time,
+        full_grads[method][0, :, 1],  # show x gradient
+        label=f"{method}",
+    )
+grad_ax[0].set_title("Full gradient waveforms with prephasor and spoiler")
+grad_ax[1].set_xlabel("Time (ms)")
+grad_ax[0].set_ylabel("Gx (T/m)")
+grad_ax[1].set_ylabel("Gy (T/m)")
+grad_ax[0].axvline(acq.raster_time * prephasors[method].shape[1], ls="--", c="gray")
+grad_ax[0].axvline(
+    acq.raster_time * (full_grads[method].shape[1] - spoilers[method].shape[1]),
+    ls="--",
+    c="gray",
+)
+grad_ax[1].axvline(acq.raster_time * prephasors[method].shape[1], ls="--", c="gray")
+grad_ax[1].axvline(
+    acq.raster_time * (full_grads[method].shape[1] - spoilers[method].shape[1]),
+    ls="--",
+    c="gray",
+)
+
+grad_ax[0].legend(loc="upper center")
+
+
+for i, method in enumerate(["lp", "lp-minslew", "osqp"]):
+    t = full_traj[method]
+    t_pre = t[:, : prephasors[method].shape[1], :]
+    t_post = t[:, -spoilers[method].shape[1] :]
+    t_core = t[:, prephasors[method].shape[1] : -spoilers[method].shape[1], :]
+
+    axs[i].scatter(
+        t_core.reshape(-1, 2)[:, 0],
+        t_core.reshape(-1, 2)[:, 1],
+        c="k",
+        s=0.5,
+    )
+
+    axs[i].scatter(
+        t_pre.reshape(-1, 2)[:, 0],
+        t_pre.reshape(-1, 2)[:, 1],
+        c="tab:blue",
+        s=0.5,
+    )
+    axs[i].scatter(
+        t_post.reshape(-1, 2)[:, 0],
+        t_post.reshape(-1, 2)[:, 1],
+        c="tab:green",
+        s=0.5,
+    )
+    axs[i].set_title(f"'{method}' prephasor/spoiler")
+    axs[i].grid()
+plt.legend()
+plt.show()
+
+# %%

--- a/examples/trajectories/example_grad_connection.py
+++ b/examples/trajectories/example_grad_connection.py
@@ -1,30 +1,27 @@
 # %%
 """
-===========================================
+============================================
 Prephasors, Spoilers and arbitrary Waveforms
 ============================================
 
-
-This example showcases how to create gradient waveform under a set of constraints. 
-
+This example showcases how to create gradient waveform under a set of constraints.
 
 When designing MRI sequences It's often necessary to have some way of going from
 a point A to point B in the kspace. For instance:
 
-- At the beginning of an
-acquisition we may want to go from the center of the k-space to the starting
-point of the trajectory. This is usually call the "prephasor" or "prewinder"
-gradient.
-- At the end of an acquisition we may want to go from the end point of
-the trajectory back to the center, or to crush any residual magnetization by
-going to the edge of the k-space. This is usually called a "rewind" or "spoiler"
-gradient.
+- At the beginning of an acquisition we may want to go from the center of the
+k-space to the starting point of the trajectory. This is usually call the
+"prephasor" or "prewinder" gradient. - At the end of an acquisition we may want
+to go from the end point of the trajectory back to the center, or to crush any
+residual magnetization by going to the edge of the k-space. This is usually
+called a "rewind" or "spoiler" gradient.
 
-However, these gradient waveforms needs to be designed under the hardware system constraints:
-The maximum gradient strength :math:`g_\max`, and slew rate :math:`s_\max`, and the raster time :math:`\Delta t`.
+However, these gradient waveforms needs to be designed under the hardware system
+constraints: The maximum gradient strength :math:`g_\max`, and slew rate
+:math:`s_\max`, and the raster time :math:`\Delta t`.
 
-Once the constraints are defined, the gradient waveforms can be determined using different methods
-such as linear programming or quadratic programming.
+Once the constraints are defined, the gradient waveforms can be determined using
+different methods such as linear programming or quadratic programming.
 
 This example shows how to create such gradient waveforms using MRI-NUFFT.
 """

--- a/examples/trajectories/example_pulseq.py
+++ b/examples/trajectories/example_pulseq.py
@@ -1,0 +1,81 @@
+# %%
+"""
+==================================
+Create a GRE Sequence using Pulseq
+==================================
+
+Example how to create sequences using PyPulseq.
+"""
+import numpy as np
+from mrinufft.trajectories.display import display_3D_trajectory
+from mrinufft.trajectories import initialize_2D_spiral, stack
+
+from mrinufft.io.pulseq import pulseq_gre, read_pulseq_traj
+import matplotlib.pyplot as plt
+
+# %%
+# Defining the sequence parameters like repetition time (TR), echo time (TE), flip angle (FA), field-of-view (FOV) and image matrix size.
+
+TR = 100  # ms
+TE = 50  # ms
+FA = 10  # degrees
+FOV = np.array([0.192, 0.192, 0.128])  # Field of View in meters
+img_size = np.array([64, 64, 48])  # Image size in pixels
+
+
+# %%
+# Create a stack of spiral for our trajectory
+
+traj = stack(
+    initialize_2D_spiral(Nc=1, Ns=4096, nb_revolutions=12, in_out=True)[:, ::-1, :],
+    nb_stacks=img_size[-1],
+)
+
+display_3D_trajectory(traj)
+
+# %%
+
+# Create a 3D GRE sequence with the trajectory:
+
+seq = pulseq_gre(traj[:3], acq=None, TR=TR, TE=TE, FA=FA)
+
+
+# %%
+
+# Let's show the sequence.
+plt.rcParams["figure.figsize"] = (20, 10)
+seq.plot(show_blocks=True, grad_disp="mT/m")
+
+# %%
+
+# %%
+read_kspace = read_pulseq_traj(seq)
+
+# %%
+KMAX = 0.5
+
+# %%
+kspace_adc, _, t_exc, t_refocus, t_adc = seq.calculate_kspace()
+
+# split t_adc with t_exc and t_refocus, the index are then used to split kspace_adc
+FOV = seq.get_definition("FOV")
+t_splits = np.sort(np.concatenate([t_exc, t_refocus]))
+idx_prev = 0
+kspace_shots = []
+for t in t_splits:
+    idx_next = np.searchsorted(t_adc, t, side="left")
+    if idx_next == idx_prev:
+        continue
+    kspace_shots.append(kspace_adc[:, idx_prev:idx_next].T)
+    if idx_next == kspace_adc.shape[1] and t > t_adc[-1]:  # last useful point
+        break
+    idx_prev = idx_next
+if idx_next < kspace_adc.shape[1]:
+    kspace_shots.append(kspace_adc[:, idx_next:].T)  # add remaining gradients.
+# convert to KMAX standard.
+kspace_shots = np.ascontiguousarray(kspace_shots) * KMAX * 2 * np.asarray(FOV)
+
+
+# %%
+# and we can display the k-space trajectory, loaded from the sequence file.
+display_3D_trajectory(kspace_shots)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pynufft = ["pynufft"]
 pynufft-cpu = ["pynufft"]
 pynufft-gpu = ["pynufft"]
 
-io = ["pymapvbvd"]
+io = ["pymapvbvd", "pypulseq"]
 extra = ["pymapvbvd", "scikit-image", "scikit-learn", "pywavelets", "osqp", "ptwt"]
 autodiff = ["torch", "deepinv"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pynufft-cpu = ["pynufft"]
 pynufft-gpu = ["pynufft"]
 
 io = ["pymapvbvd"]
-extra = ["pymapvbvd", "scikit-image", "scikit-learn", "pywavelets", "ptwt"]
+extra = ["pymapvbvd", "scikit-image", "scikit-learn", "pywavelets", "osqp", "ptwt"]
 autodiff = ["torch", "deepinv"]
 
 

--- a/src/mrinufft/_utils.py
+++ b/src/mrinufft/_utils.py
@@ -119,7 +119,7 @@ class MethodRegister:
         List of potential subsititutions to apply to the docstring.
     """
 
-    registry = defaultdict(dict)
+    registry_global = defaultdict(dict)
 
     def __init__(
         self, register_name: str, docstring_subs: dict[str, str] | None = None
@@ -134,7 +134,7 @@ class MethodRegister:
         """
 
         def decorator(func):
-            self.registry[self.register_name][method_name] = func
+            self.registry[method_name] = func
             func = _apply_docstring_subs(func, self.docstring_subs or {})
             return func
 
@@ -150,12 +150,12 @@ class MethodRegister:
 
         def getter(method_name, *args, **kwargs):
             try:
-                method = self.registry[self.register_name][method_name]
+                method = self.registry[method_name]
             except KeyError as e:
                 raise ValueError(
                     f"Unknown {self.register_name} method {method_name}."
                     " Available methods are \n"
-                    f"{list(self.registry[self.register_name].keys())}"
+                    f"{list(self.registry.keys())}"
                 ) from e
 
             if args or kwargs:
@@ -165,6 +165,11 @@ class MethodRegister:
         getter.__doc__ = f"""Get the {self.register_name} function from its name."""
         getter.__name__ = f"get_{self.register_name}"
         return getter
+
+    @property
+    def registry(self):
+        """Get the registry dictionary."""
+        return self.registry_global[self.register_name]
 
 
 def _progressbar(progressbar: bool | tqdm, max_iter: int) -> tqdm:

--- a/src/mrinufft/io/__init__.py
+++ b/src/mrinufft/io/__init__.py
@@ -3,13 +3,15 @@
 from .cfl import traj2cfl, cfl2traj
 from .nsp import read_trajectory, write_trajectory, read_arbgrad_rawdat
 from .siemens import read_siemens_rawdat
-
+from .pulseq import read_pulseq_traj, pulseq_gre
 
 __all__ = [
-    "traj2cfl",
     "cfl2traj",
-    "read_trajectory",
-    "write_trajectory",
+    "pulseq_gre",
     "read_arbgrad_rawdat",
+    "read_pulseq_traj",
     "read_siemens_rawdat",
+    "read_trajectory",
+    "traj2cfl",
+    "write_trajectory",
 ]

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -8,6 +8,7 @@ import warnings
 from array import array
 from datetime import datetime
 
+from mrinufft.trajectories.gradients import connect_gradient
 import numpy as np
 
 from mrinufft.trajectories.utils import (
@@ -23,7 +24,7 @@ from mrinufft.trajectories.utils import (
     KMAX,
     DEFAULT_RASTER_TIME,
 )
-from mrinufft.trajectories.tools import get_gradient_amplitudes_to_travel_for_set_time
+from mrinuff.trajectories.gradients import get_prephasors_and_spoilers
 
 from .siemens import read_siemens_rawdat
 
@@ -210,8 +211,8 @@ def _pop_elements(array, num_elements=1, type=np.float32):
 
 def write_trajectory(
     trajectory: np.ndarray,
-    FOV: tuple[float, ...],
-    img_size: tuple[int, ...],
+    FOV: tuple[float, float, float],
+    img_size: tuple[int, int, int],
     grad_filename: str,
     norm_factor: float = KMAX,
     gamma: float = Gammas.HYDROGEN / 1e3,
@@ -287,38 +288,49 @@ def write_trajectory(
     )
     Ns_to_skip_at_start = 0
     Ns_to_skip_at_end = 0
-    if pregrad == "prephase":
+    if pregrad or postgrad:
         if version < 5.1:
             raise ValueError(
-                "pregrad is only supported for version >= 5.1, "
+                "pregrad and postgrad are only supported for version >= 5.1, "
                 "please set version to 5.1 or higher."
             )
-        start_gradients = get_gradient_amplitudes_to_travel_for_set_time(
-            kspace_end_loc=initial_positions,
-            end_gradients=gradients[:, 0],
-            acq=acq,
-        )
-        initial_positions = np.zeros_like(initial_positions)
-        gradients = np.hstack([start_gradients, gradients])
-        Ns_to_skip_at_start = start_gradients.shape[1]
-    if postgrad:
-        if version < 5.1:
-            raise ValueError(
-                "postgrad is only supported for version >= 5.1, "
-                "please set version to 5.1 or higher."
+        prephase_grad = prephase_loc = spoiler_grad = spoiler_loc = None
+        if pregrad == "prephase":
+            prephase_grad = np.zeros_like(initial_positions)
+            prephase_loc = np.zeros_like(initial_positions)
+
+            prephasors = connect_gradient(
+                prephase_loc,
+                initial_positions,
+                prephase_grad,
+                gradients[:, 0, :],
+                acq,
+                method="auto",
+                N=None,
             )
-        edge_locations = np.zeros_like(final_positions)
-        if postgrad == "slowdown_to_edge":
-            # Always end at KMax, the spoilers can be handeled by the sequence.
-            edge_locations[..., 0] = img_size[0] / FOV[0] / 2
-        end_gradients = get_gradient_amplitudes_to_travel_for_set_time(
-            kspace_end_loc=edge_locations,
-            start_gradients=gradients[:, -1],
-            kspace_start_loc=final_positions,
-            acq=acq,
-        )
-        gradients = np.hstack([gradients, end_gradients])
-        Ns_to_skip_at_end = end_gradients.shape[1]
+            Ns_to_skip_at_start = prephasors.shape[1]
+            gradients = np.concatenate((prephasors, gradients), axis=1)
+        if postgrad == "slowdown_to_center":
+            spoiler_loc = np.zeros_like(final_positions)
+            spoiler_grad = np.zeros_like(final_positions)
+        elif postgrad == "slowdown_to_edge":
+            spoiler_loc = np.zeros_like(final_positions)
+            spoiler_loc[..., 0] = img_size[0] / FOV[0] / 2
+            spoiler_grad = np.zeros_like(final_positions)
+
+        if postgrad:
+            spoilers = connect_gradient(
+                final_positions,
+                spoiler_loc,
+                spoiler_grad,
+                gradients[:, -1, :],
+                acq,
+                method="auto",
+                N=None,
+            )
+            Ns_to_skip_at_end = spoilers.shape[1]
+            gradients = np.concatenate((gradients, spoilers), axis=1)
+
     # Check constraints if requested
     if check_constraints:
         slewrates, _ = convert_gradients_to_slew_rates(gradients, acq)

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -24,7 +24,7 @@ from mrinufft.trajectories.utils import (
     KMAX,
     DEFAULT_RASTER_TIME,
 )
-from mrinuff.trajectories.gradients import get_prephasors_and_spoilers
+from mrinufft.trajectories.gradients import get_prephasors_and_spoilers
 
 from .siemens import read_siemens_rawdat
 

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -223,6 +223,7 @@ def write_trajectory(
     smax: float = DEFAULT_SMAX,
     pregrad: str | None = None,
     postgrad: str | None = None,
+    grad_method: str = "auto",
     version: float = 5,
     **kwargs,
 ):
@@ -305,11 +306,12 @@ def write_trajectory(
                 prephase_grad,
                 gradients[:, 0, :],
                 acq,
-                method="auto",
+                method=grad_method,
                 N=None,
             )
             Ns_to_skip_at_start = prephasors.shape[1]
             gradients = np.concatenate((prephasors, gradients), axis=1)
+            initial_positions = prephase_loc
         if postgrad == "slowdown_to_center":
             spoiler_loc = np.zeros_like(final_positions)
             spoiler_grad = np.zeros_like(final_positions)
@@ -330,6 +332,7 @@ def write_trajectory(
             )
             Ns_to_skip_at_end = spoilers.shape[1]
             gradients = np.concatenate((gradients, spoilers), axis=1)
+            final_positions = spoiler_loc
 
     # Check constraints if requested
     if check_constraints:

--- a/src/mrinufft/io/pulseq.py
+++ b/src/mrinufft/io/pulseq.py
@@ -25,6 +25,7 @@ try:
     import pypulseq as pp
 except ImportError:
     PULSEQ_AVAILABLE = False
+    pp = None
 
 
 def read_pulseq_traj(
@@ -116,7 +117,7 @@ def _check_timings(seq):
         warnings.warn("Timing check failed. Error listing follows:" + str(error_report))
 
 
-def acq2opts(acq: Acquisition) -> pp.Opts:
+def acq2opts(acq: Acquisition) -> "pp.Opts":
     """Convert an Acquisition object to pypulseq Opts.
 
     Parameters

--- a/src/mrinufft/io/pulseq.py
+++ b/src/mrinufft/io/pulseq.py
@@ -1,0 +1,326 @@
+"""Pulseq Trajectory Reader and writers.
+
+Reads Pulseq `.seq` files to extract k-space trajectory and other parameters. It
+also provides functionality to create pulseq block and shape objects to
+facilitate the integration of arbitrary k-space trajectories into Pulseq
+sequences. Requires the `pypulseq` package to be installed.
+"""
+
+import warnings
+from types import SimpleNamespace
+
+import numpy as np
+from numpy.typing import NDArray
+
+from mrinufft.trajectories.utils import (
+    Acquisition,
+    Hardware,
+    convert_trajectory_to_gradients,
+)
+
+from mrinufft.trajectories.gradients import get_prephasors_and_spoilers
+
+PULSEQ_AVAILABLE = True
+try:
+    import pypulseq as pp
+except ImportError:
+    PULSEQ_AVAILABLE = False
+
+
+def read_pulseq_traj(
+    seq, trajectory_delay=0.0, gradient_offset=0.0
+) -> tuple[NDArray, dict, Acquisition]:
+    """Extract k-space trajectory from a Pulseq sequence file.
+
+    The sequence should be a valid Pulseq `.seq` file, with arbitrary gradient
+    waveforms, which all have the same length.
+
+
+    Parameters
+    ----------
+    sequence : pulseq Sequence, or Path to the Pulseq `.seq` file.
+        The Pulseq sequence object or the path to the `.seq` file.
+    trajectory_delay : float, optional
+        Compensation factor in seconds (s) to align ADC and gradients.
+    gradient_offset : float, optional
+        Simulates background gradients (specified in Hz/m)
+
+    Returns
+    -------
+    NDArray
+        The k-space trajectory as a numpy array of shape (n_shots, n_samples, 3),
+        where the last dimension corresponds to the x, y, and z coordinates in k-space.
+    dict
+        the [DESCRIPTION] block from the sequence file.
+    Acquisition
+        The acquisition parameters extracted from the sequence.
+
+    """
+    if not PULSEQ_AVAILABLE:
+        raise ImportError(
+            "The `pypulseq` package is required for this function. "
+            "Please install it via `pip install pypulseq` or "
+            "`pip install mri-nufft[io]`."
+        )
+    if not isinstance(seq, pp.Sequence):
+        filename = seq
+        seq = pp.Sequence()
+        seq.read(filename)
+
+    kspace_adc, _, t_exc, t_refocus, t_adc = seq.calculate_kspace(
+        trajectory_delay=trajectory_delay, gradient_offset=gradient_offset
+    )
+
+    if not len(t_adc):
+        raise ValueError(
+            "The sequence does not contain any ADC events. "
+            "Please ensure that the sequence has ADC events defined."
+        )
+    # split t_adc with t_exc and t_refocus, the index are then used to split kspace_adc
+    t_splits = np.sort(np.concatenate([t_exc, t_refocus]))
+    idx_prev = 0
+    kspace_shots = []
+    for t in t_splits:
+        idx_next = np.searchsorted(t_adc, t, side="left")
+        if idx_next == idx_prev:
+            continue
+        kspace_shots.append(kspace_adc[:, idx_prev:idx_next].T)
+        if idx_next == kspace_adc.shape[1] and t > t_adc[-1]:  # last useful point
+            break
+        idx_prev = idx_next
+    if idx_next < kspace_adc.shape[1]:
+        kspace_shots.append(kspace_adc[:, idx_next:].T)  # add remaining gradients.
+    # convert to KMAX standard.
+    #
+    acq = Acquisition(
+        fov=seq.get_definition("FOV"),
+        img_size=seq.get_definition("ImgSize"),
+        adc_dwell_time=seq.system.adc_raster_time,
+        hardware=Hardware(
+            grad_raster_time=seq.system.grad_raster_time,
+            gmax=seq.system.max_grad / 1e3,  # FIXME: assumes mT/m in pulseq
+            smax=seq.system.max_slew,
+        ),
+        gamma=seq.system.gamma / (2 * np.pi),
+    )
+    kspace_shots = np.ascontiguousarray(kspace_shots)
+    return kspace_shots, seq.definitions, acq
+
+
+def _check_timings(seq):
+    # Check whether the timing of the sequence is correct
+    ok, error_report = seq.check_timing()
+    if ok:
+        return None
+    else:
+        warnings.warn("Timing check failed. Error listing follows:" + str(error_report))
+
+
+def acq2opts(acq: Acquisition) -> pp.Opts:
+    """Convert an Acquisition object to pypulseq Opts.
+
+    Parameters
+    ----------
+    acq : Acquisition
+        The acquisition parameters.
+
+    Returns
+    -------
+    pp.Opts
+        The corresponding pypulseq Opts object.
+    """
+    if not PULSEQ_AVAILABLE:
+        raise ImportError(
+            "The `pypulseq` package is required for this function. "
+            "Please install it via `pip install pypulseq` or "
+            "`pip install mri-nufft[io]`."
+        )
+    system = pp.Opts(
+        max_grad=acq.gmax * 1e3,  # convert to mT/m
+        grad_unit="mT/m",
+        max_slew=acq.smax,
+        slew_unit="T/m/s",
+        gamma=acq.gamma,
+        grad_raster_time=acq.grad_raster_time,
+        adc_raster_time=acq.adc_dwell_time,
+    )
+    return system
+
+
+def pulseq_gre(
+    trajectory: NDArray | tuple[NDArray, NDArray, NDArray],
+    TR: float,
+    TE: float,
+    TE_pos: float = 0.5,
+    FA: float | None = None,
+    rf_pulse: SimpleNamespace | None = None,
+    rf_spoiling_inc: float = 0.0,
+    grad_spoil_factor: float = 2.0,
+    acq: Acquisition | None = None,
+    connect_method: str = "auto",
+):
+    """Create a Pulseq 3D-GRE sequence for arbitrary trajectories.
+
+    Parameters
+    ----------
+    trajectory : np.ndarray
+        The k-space trajectory as a numpy array of shape (n_shots, n_samples, 3),
+        where the last dimension corresponds to the x, y, and z coordinates in k-space.
+    TR: float
+        The repetition time in milliseconds (ms).
+    TE: float
+        The echo time in milliseconds (ms).
+    FA: float, optional, incompatible with `rf_pulse`
+        The flip angle in degrees (°).
+    TE_pos: float, optional
+        The relative (0-1) position of the echo time within each kspace_shot.
+    rf_pulse: SimpleNamespace, optional, incompatible with `FA`
+        A custom radio-frequency pulse object. If not provided, a block pulse
+        with the specified flip angle and a duration of 4 ms will be created.
+        see `pypulseq.make_block_pulse` or `pypulseq.make_arbitrary_rf` for more
+        details.
+    rf_spoiling_inc: float, optional
+        The increment in the RF phase (in degree) for spoiling. Default is 0.0,
+        which means no spoiling.
+    gre_2D: bool, optional
+        If True, the sequence will be a 2D GRE sequence. Default is False,
+        which means a 3D GRE sequence.
+    slice_overlap: float, optional
+        The slice overlap proportion for 2D GRE sequences. Default is 0.0
+        Positive values indicates an overlap, negative values indicates a gap.
+    grad_spoil_factor: float, optional
+        How much the spoiler gradient moves to the edge of k-space. Default is 2.0.
+    osf: int, optional
+        The oversampling factor for the ADC. Default is 1, which means no oversampling.
+
+    system : pypulseq.Opts, optional
+        The system options for the Pulseq sequence. Default is `pp.Opts.default`.
+
+    Notes
+    -----
+    The  Sequence cycle can be summarized as follows:
+
+    1. RF pulse
+    2. Delay to sync TE
+    3. Gradients plays: The gradients consist in a prewind to the first point
+    of the trajectory, the trajectory itself, and a rewind to the edge of
+    k-space.
+    3bis. The ADC is opened on the trajectory points (ignoring the prewind and
+    rewinds parts)
+    4. Gradient spoilers
+    5. Delay to sync the next TR
+
+
+    If `gre_2D` is True, the sequence will be a 2D GRE sequence, and the slice
+    thickness will be determined as :math:`(FOV[2] / img_size[2]) *
+    (1+slice_overlap)`
+
+    Returns
+    -------
+    pp.Sequence
+        A Pulseq sequence object with the specified arbitrary gradient waveform.
+    """
+    if not PULSEQ_AVAILABLE:
+        raise ImportError(
+            "The `pypulseq` package is required for this function. "
+            "Please install it via `pip install pypulseq` "
+            "or `pip install mri-nufft[io]`."
+        )
+
+    acq = acq or Acquisition.default
+
+    TR = TR / 1000.0  # convert to seconds
+    TE = TE / 1000.0  # convert to seconds
+    system = acq2opts(acq)
+    seq = pp.Sequence(system=system)
+
+    if rf_pulse is None and FA is not None:
+        rf_pulse = pp.make_block_pulse(flip_angle=FA, system=system, use="excitation")
+    elif rf_pulse is not None and FA is not None:
+        raise ValueError(
+            "Cannot specify both `rf_pulse` and `FA`. Please provide only one."
+        )
+    elif rf_pulse is None and FA is None:
+        raise ValueError("Either `rf_pulse` or `FA` must be provided.")
+
+    if not isinstance(rf_pulse, SimpleNamespace):
+        raise TypeError(
+            "The `rf_pulse` parameter must be a SimpleNamespace object, "
+            "as returned by `pypulseq.make_block_pulse` or `pypulseq.make_arbitrary_rf`"
+        )
+    if FA is None:
+        # Compute the flip angle from the RF pulse
+        FA = float(
+            abs(np.sum(rf_pulse.signal[:-1] * (rf_pulse.t[1:] - rf_pulse.t[:-1]))) * 360
+        )
+
+    seq.set_definition("FOV", acq.fov)
+    seq.set_definition("ImgSize", acq.img_size)
+    seq.set_definition("TR", TR)
+    seq.set_definition("TE", TE)
+    seq.set_definition("FA", FA)
+
+    if isinstance(trajectory, tuple | list):
+        prephase_grad, traj_grad, spoiler_grad = trajectory
+    else:
+        traj_grad, _ = convert_trajectory_to_gradients(trajectory, acq)
+        prephase_grad, spoiler_grad = get_prephasors_and_spoilers(
+            trajectory,
+            acq=acq,
+            spoil_loc=(grad_spoil_factor, 0, 0),
+            method=connect_method,
+        )
+
+    full_grads = np.concatenate([prephase_grad, traj_grad, spoiler_grad], axis=1)
+    skip_start = prephase_grad.shape[1]
+    skip_end = spoiler_grad.shape[1]
+
+    traj_length = full_grads.shape[1] - skip_start - skip_end + 1
+    shot_duration = system.grad_raster_time * traj_length  # in seconds
+    adc = pp.make_adc(
+        num_samples=traj_length * system.grad_raster_time // system.adc_raster_time,
+        system=system,
+        # duration=shot_duration,
+        dwell=system.adc_raster_time,
+        delay=skip_start * system.grad_raster_time,
+    )
+
+    # Add a spoiler gradient that move to twice the edge of k-space in the x direction.
+
+    delay_before_grad = pp.make_delay(
+        TE
+        - pp.calc_rf_center(rf_pulse)[0]
+        - rf_pulse.delay
+        - TE_pos * shot_duration
+        - skip_start * system.grad_raster_time
+    )
+    delay_end_TR = pp.make_delay(
+        TR
+        - pp.calc_duration(rf_pulse)
+        - delay_before_grad.delay
+        - full_grads.shape[1] * system.grad_raster_time
+    )
+
+    rf_phase = 0.0
+    for grad_xyz in full_grads:
+        rf_phase = divmod(rf_phase + rf_spoiling_inc, 360.0)[1]
+        rf_pulse.phase_offset = rf_phase / 180 * np.pi
+        adc.phase_offset = rf_phase / 180 * np.pi
+        seq.add_block(rf_pulse)  # RF pulse
+        seq.add_block(delay_before_grad)  # delay to sync TE
+        # Add the gradient waveform, the first/last points are set to 0
+        # to avoid accumulating offsets between shots
+        # https://github.com/imr-framework/pypulseq/discussions/175
+        seq.add_block(
+            *[
+                pp.make_arbitrary_grad(
+                    channel=c, waveform=grad_xyz[:, i], first=0, last=0, system=system
+                )
+                for i, c in enumerate("xyz")
+            ],
+            adc,
+        )
+        seq.add_block(delay_end_TR)
+
+    _check_timings(seq)
+    return seq

--- a/src/mrinufft/io/utils.py
+++ b/src/mrinufft/io/utils.py
@@ -1,10 +1,13 @@
 """Module containing utility functions for IO in MRI NUFFT."""
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy.spatial.transform import Rotation
 
 
-def add_phase_to_kspace_with_shifts(kspace_data, kspace_loc, normalized_shifts):
+def add_phase_to_kspace_with_shifts(
+    kspace_data: NDArray, kspace_loc: NDArray, normalized_shifts: NDArray
+):
     """
     Add phase shifts to k-space data.
 
@@ -38,7 +41,7 @@ def add_phase_to_kspace_with_shifts(kspace_data, kspace_loc, normalized_shifts):
     return kspace_data * phase
 
 
-def siemens_quat_to_rot_mat(quat, return_det=False):
+def siemens_quat_to_rot_mat(quat: NDArray, return_det=False):
     """
     Calculate the rotation matrix from Siemens Twix quaternion.
 
@@ -134,7 +137,7 @@ def nifti_affine(twixObj):
     return full_mat
 
 
-def remove_extra_kspace_samples(kspace_data, num_samples_per_shot):
+def remove_extra_kspace_samples(kspace_data: NDArray, num_samples_per_shot: int):
     """Remove extra samples from k-space data.
 
     This function is useful when the k-space data has extra samples

--- a/src/mrinufft/trajectories/gradients.py
+++ b/src/mrinufft/trajectories/gradients.py
@@ -344,6 +344,13 @@ def _solve_qp_osqp(
 
     """
     # Quadratic terms
+
+    # Croping for safety
+    if abs(ge) > gmax:
+        ge = gmax * ge / abs(ge)
+    if abs(gs) > gmax:
+        gs = gmax * gs / abs(gs)
+
     if OSQP_AVAILABLE is False:
         raise RuntimeError("osqp package not found. Install it with `pip install osqp`")
 

--- a/src/mrinufft/trajectories/gradients.py
+++ b/src/mrinufft/trajectories/gradients.py
@@ -419,7 +419,7 @@ def _solve_qp_osqp(
         P=H, q=q, A=A, l=lower, u=upper, verbose=False, eps_abs=1e-8, eps_rel=1e-8
     )
     res = prob.solve()
-    return res.x, res.info.status == "solved"
+    return res.x, res.info.status_val <= 2  # 1: solved, 2: solved inaccurate
 
 
 @_solvers("auto")

--- a/src/mrinufft/trajectories/gradients.py
+++ b/src/mrinufft/trajectories/gradients.py
@@ -3,9 +3,20 @@
 from collections.abc import Callable
 
 import numpy as np
+import scipy as sp
 import numpy.linalg as nl
 from numpy.typing import NDArray
 from scipy.interpolate import CubicSpline
+from scipy.optimize import linprog
+from functools import partial
+
+from mrinufft.trajectories.utils import Acquisition
+
+OSQP_AVAILABLE = True
+try:
+    import osqp
+except ImportError:
+    OSQP_AVAILABLE = False
 
 
 def patch_center_anomaly(
@@ -119,3 +130,435 @@ def patch_center_anomaly(
 
     single_shot = update_shot(*parameters)
     return single_shot, parameters
+
+
+#########################
+# Gradients connections #
+#########################
+
+
+def _solve_lp_1d(
+    N: int, Deltakx: float, gmax: float, smax: float, gx_start: float, gx_end: float
+) -> tuple[NDArray, bool]:
+    """Solve a linear programming problem for getting 1D waveform.
+
+    Such that:
+
+    - sum(x) = Deltakx
+    - |x[i]| <= gmax
+    - |x[i+1]-x[i]| <= smax
+    - x[0] = gx_start
+    - x[N-1] = gx_end
+
+    Parameters
+    ----------
+    N: int
+        Number of time points for the gradient waveform
+    Deltakx: float
+        Desired change in k-space
+    gmax: float
+        Maximum gradient amplitude
+    smax: float
+        Maximum slew rate
+    gx_start: float
+        Starting gradient value
+    gx_end: float
+        Ending gradient value
+
+    Returns
+    -------
+    scipy.optimize.OptimizeResult
+        The result of the linear programming optimization containing the optimized
+        gradient waveform and information about the optimization process.
+
+    Notes
+    -----
+    The inputs are normalized by gamma and raster_time. You almost certainly want to
+    use `optimize_grad` instead of this function directly.
+    """
+    # Croping for safety
+    if abs(gx_end) > gmax:
+        gx_end = gmax * gx_end / abs(gx_end)
+    if abs(gx_start) > gmax:
+        gx_start = gmax * gx_start / abs(gx_start)
+
+    c = np.ones(N)
+    # 2. Variable Bounds
+    # The bounds apply to all variables across all dimensions
+    bounds = np.full((N, 2), [-gmax, gmax])
+
+    # 3. Equality Constraints (A_eq, b_eq)
+    A_eq = np.zeros((3, N))
+    b_eq = np.array([Deltakx, gx_start, gx_end])
+    A_eq[0, :] = 1  # Sum x = Deltakx
+    A_eq[1, 0] = 1  # x[0] = gx_start
+    A_eq[2, N - 1] = 1  # x[N-1] = gx_end
+
+    # 4. Inequality Constraints (A_ub, b_ub)
+    # Slew rate constraints: 2 * (N-1) per dimension * 3 dimensions
+    num_ub = 2 * (N - 1)
+    A_ub = np.zeros((num_ub, N))
+    b_ub = smax * np.ones(num_ub)
+    # Fill in the A_ub matrix for each dimension
+    # This creates the following pattern:
+    #
+    # [[ 1, -1, 0, ..., 0]
+    #  [ 0 , 1, -1, ..., 0]
+    #   ...
+    #  [-1,  1, 0, ..., 0]
+    #  [ 0, -1, 1, ..., 0]
+    #   ...]
+    # First N-1 rows for positive slew rate constraints (x[t+1] - x[t] <= smax)
+    # Next N-1 rows for negative slew rate constraints (x[t+1] - x[t] >= -smax)
+    for t in range(N - 1):
+        # Constraints for X dimension
+        A_ub[t, t] = -1
+        A_ub[t, t + 1] = 1
+        A_ub[t + N - 1, t] = 1
+        A_ub[t + N - 1, t + 1] = -1
+
+    # 5. Solve the LP
+    A_ub = A_ub.astype(np.float32)
+    b_ub = b_ub.astype(np.float32)
+    A_eq = A_eq.astype(np.float32)
+    b_eq = b_eq.astype(np.float32)
+
+    res = linprog(
+        c,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        A_eq=A_eq,
+        b_eq=b_eq,
+        bounds=bounds,
+        method="highs-ds",
+        options={"verbose": 1},
+    )
+    return res.x, res.success
+
+
+def _build_quadratic(
+    N: int, gx_start: float, gx_end: float
+) -> tuple[NDArray, NDArray, NDArray]:
+    """
+    Build reduced quadratic form.
+
+    for u = x[1:-1], with endpoints fixed at gx_start and gx_end.
+    """
+    # Sparse second-difference matrix R (size (N-2) x N)
+    data = []
+    rows = []
+    cols = []
+    for i in range(1, N - 1):
+        rows += [i - 1, i - 1, i - 1]
+        cols += [i - 1, i, i + 1]
+        data += [1, -2, 1]
+    R = sp.csr_matrix((data, (rows, cols)), shape=(N - 2, N))
+
+    # Quadratic form
+    H_full = 2 * (R.T @ R)  # sparse symmetric
+
+    free_idx = np.arange(1, N - 1)
+    fixed_idx = np.array([0, N - 1])
+
+    # submatrix slicing with np.ix_
+    H_ff = H_full[np.ix_(free_idx, free_idx)].tocsc()
+    H_fb = H_full[np.ix_(free_idx, fixed_idx)].toarray()
+    H_bb = H_full[np.ix_(fixed_idx, fixed_idx)].toarray()
+
+    b = np.array([gx_start, gx_end])
+
+    q = H_fb @ b
+    c = 0.5 * b @ (H_bb @ b)
+
+    return H_ff, q, c
+
+
+def _solve_qp_osqp(
+    N: int, Delta_kx: float, gmax: float, smax: float, gx_start: float, gx_end: float
+) -> tuple[NDArray, bool]:
+    # Quadratic terms
+    H, q, c = _build_quadratic(N, gx_start, gx_end)
+    nvar = N - 2
+
+    # Constraint builder lists
+    data = []
+    rows = []
+    cols = []
+    lower = []
+    upper = []
+
+    # (1) Equality: sum(u) = Delta_kx - gx_start - gx_end
+    for j in range(nvar):
+        data.append(1.0)
+        rows.append(0)
+        cols.append(j)
+    lower.append(Delta_kx - gx_start - gx_end)
+    upper.append(Delta_kx - gx_start - gx_end)
+    row_counter = 1
+
+    # (2) Inequality: slope constraints
+    # left slope: u1 - gx_start
+    data += [1.0]
+    rows += [row_counter]
+    cols += [0]
+    lower.append(-smax + gx_start)
+    upper.append(smax + gx_start)
+    row_counter += 1
+
+    # right slope: gx_end - u_{N-2}
+    data += [-1.0]
+    rows += [row_counter]
+    cols += [nvar - 1]
+    lower.append(-smax - gx_end)
+    upper.append(smax - gx_end)
+    row_counter += 1
+
+    # interior slopes: u[i+1] - u[i]
+    for i in range(nvar - 1):
+        data += [-1.0, 1.0]
+        rows += [row_counter, row_counter]
+        cols += [i, i + 1]
+        lower.append(-smax)
+        upper.append(smax)
+        row_counter += 1
+
+    # (3) Bounds: -gmax <= u[i] <= gmax
+    for i in range(nvar):
+        data.append(1.0)
+        rows.append(row_counter)
+        cols.append(i)
+        lower.append(-gmax)
+        upper.append(gmax)
+        row_counter += 1
+
+    # Build sparse A
+    A = sp.csc_matrix((data, (rows, cols)), shape=(row_counter, nvar))
+    lower = np.array(lower)
+    upper = np.array(upper)
+
+    # OSQP setup
+    prob = osqp.OSQP()
+    prob.setup(
+        P=H, q=q, A=A, l=lower, u=upper, verbose=False, eps_abs=1e-8, eps_rel=1e-8
+    )
+    res = prob.solve()
+    return res.x, res.info.status == "solved"
+
+
+def _binary_search_int(
+    f: Callable[[int], tuple[NDArray, bool]], low: int, high: int
+) -> tuple[NDArray, int]:
+    """Perfom a binary search to get best optimal result on f."""
+    i = 0
+    x = None
+    val = 0
+    while low <= high:
+        mid = int(low + (high - low) * 0.8)
+        new_x, success = f(mid)
+        if success:
+            x = new_x
+            high = mid - 1
+            val = mid
+        else:
+            low = mid + 1
+        i += 1
+    if x is None:
+        raise RuntimeError(f"Could not find a solution {i}, {mid}, {high}, {low}")
+    return x, val
+
+
+def _binary_search_float(
+    f: Callable[[float], tuple[NDArray, bool]], low: float, high: float
+) -> tuple[NDArray, float]:
+    """Perfom a binary search to get best optimal result on f."""
+    i = 0
+    x = None
+    while low <= high:
+        mid = low + (high - low) * 0.8
+        new_x, success = f(mid)
+        if success:
+            x = new_x
+            high = mid
+        else:
+            low = mid
+        i += 1
+    if x is None:
+        raise RuntimeError(f"Could not find a solution {i}, {mid}, {high}, {low}")
+    return x, mid
+
+
+def _optimize_grad_dimless(
+    deltak: NDArray,
+    gmax: float,
+    smax: float,
+    ge: NDArray,
+    gs: NDArray,
+    N_max: int = 5000,
+    method="osqp",
+) -> NDArray:
+    """Optimize gradient waveform in time-dimensionless units.
+
+    Parameters
+    ----------
+    deltak:
+        desired k-space change for each dimension (x,y,z)
+    gmax:
+        maximum gradient amplitude
+    smax:
+        maximum slew rate (gradient change per time point)
+    gs:
+        starting gradient value for each dimension (x,y,z)
+    ge:
+        ending gradient value for each dimension (x,y,z)
+
+    N_max:
+        maximum number of time points to use.
+
+    Returns
+    -------
+    NDArray
+        Optimized gradient waveform of shape (N, len(deltak))
+
+    Raises
+    ------
+    RuntimeError
+        If no solution is found within the maximum number of time points.
+
+    Notes
+    -----
+    This function uses a binary search to find the minimum number of time points
+    required to achieve the desired k-space change while satisfying the gradient
+    and slew rate constraints. The first dimension with the largest k-space change
+    is used to guide the search, and then the solution is applied to all dimensions.
+
+    Each dimension is optimized independently using linear programming.
+    """
+    solver = _solve_lp_1d
+    if method == "osqp":
+        if not OSQP_AVAILABLE:
+            raise ValueError(
+                "osqp package not found. Install it with `pip install osqp`"
+            )
+        solver = _solve_qp_osqp
+
+    idx_max = np.argmax(abs(deltak))
+    deltak_max = deltak[idx_max]
+    ge_max = ge[idx_max]
+    gs_max = gs[idx_max]
+
+    # Lower bound: Assuming maximum gradient all the time
+    low = int(abs(deltak_max) / gmax) + 1
+    # Upper bound: Lower bound + time to go back and forth at max slew rates
+    high = low + 2 * int(gmax / smax)
+    high = min(high, N_max)
+
+    x, N = _binary_search_int(
+        partial(solver, deltak=deltak_max, gmax=gmax, smax=smax, gs=gs_max, ge=ge_max),
+        low,
+        high,
+    )
+
+    final = np.zeros((len(x), 3))
+    # now try to reduce the slew rate to smooth the waveform
+    for idx in range(len(deltak)):
+        if method == "lp":
+            x, _ = _binary_search_float(
+                partial(
+                    solver, N=N, deltak=deltak[idx], gmax=gmax, gs=gs[idx], ge=ge[idx]
+                ),
+                low=0.001 * smax,
+                high=smax,
+            )
+        else:
+            x, success = solver(N, deltak[idx], gmax, smax, gs[idx], ge[idx])
+        if x is None or not success:
+            raise ValueError("Failed to complete optimization.")
+        final[:, idx] = x
+    return final
+
+
+def optimize_grad(
+    ks: NDArray,
+    ke: NDArray,
+    gs: NDArray,
+    ge: NDArray,
+    acq: Acquisition,
+    N: int | None = None,
+    method="lp",
+) -> NDArray:
+    """
+    Optimize a gradient waveform under hardware constraints.
+
+    Parameters
+    ----------
+    ks: NDArray
+        Starting k-space position (1/m)
+    ke: NDArray
+        Ending k-space position (1/m)
+    gs: NDArray
+        Starting gradient value (T/m)
+    ge: NDArray
+        Ending gradient value (T/m)
+    acq: Acquisition
+        Acquisition object defining hardware constraints and imaging parameters
+    N: int, optional
+        Number of time points to use. If None, the function will automatically
+        determine the optimal number of time points.
+
+    Returns
+    -------
+    NDArray
+        Optimized gradient waveform of shape (N, len(ks))
+
+    Raises
+    ------
+    RuntimeError
+        If N is provided and is too small to achieve the desired k-space change
+        while satisfying the gradient and slew rate constraints.
+
+    Notes
+    -----
+    This function calculates the required change in k-space and uses either a
+    binary search to find the minimum number of time points needed (if N is
+    None) or directly solves the linear programming problem for the provided N.
+    The optimization is performed independently for each dimension (x, y, z)
+    using the `solve_lp_1d` function.
+    """
+    deltak = (ke - ks) / acq.raster_time / acq.gamma
+    if N is None:  # Auto find the best connection
+        return _optimize_grad_dimless(
+            deltak, acq.gmax, acq.smax * acq.raster_time, gs, ge, method=method
+        )
+
+    res = []
+    solver = _solve_lp_1d
+    if method == "osqp":
+        if not OSQP_AVAILABLE:
+            raise ValueError("osqp is not availble. install it with `pip install osqp`")
+        solver = _solve_qp_osqp
+
+    for i in range(len(ks)):
+        res.append(
+            solver(N, deltak[i], acq.gmax, acq.smax * acq.raster_time, gs[i], ge[i])
+        )
+
+    # now try to reduce the slew rate to smooth the waveform
+    if all(r[1] for r in res) and method == "lp":
+        final = np.zeros((len(res[0][0]), 3))
+        orig_smax = acq.smax * acq.raster_time
+        gmax = acq.gmax
+        for idx in range(len(deltak)):
+            max_smax = orig_smax
+            min_smax = 0.01 * orig_smax
+            while (max_smax - min_smax) / min_smax >= 0.1:
+                smax = min_smax + (max_smax - min_smax) * 0.8
+                x, success = solver(N, deltak[idx], gmax, smax, gs[idx], ge[idx])
+                if success:
+                    max_smax = smax
+                    best = x
+                else:
+                    min_smax = smax
+            final[:, idx] = best
+    else:
+        raise RuntimeError("N submitted and too short")
+    return final

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -1,6 +1,6 @@
 """Functions to manipulate/modify trajectories."""
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from collections.abc import Callable
 from functools import partial
 
@@ -9,13 +9,10 @@ from numpy.typing import NDArray
 import numpy.linalg as nl
 from scipy.interpolate import CubicSpline, interp1d
 from scipy.stats import norm
-from scipy.optimize import minimize_scalar
-from joblib import Parallel, delayed
 
 from .maths import Rv, Rx, Ry, Rz
 from .utils import (
     KMAX,
-    Acquisition,
     Packings,
     initialize_shape_norm,
     VDSorder,
@@ -381,287 +378,6 @@ def unepify(trajectory: NDArray, Ns_readouts: int, Ns_transitions: int) -> NDArr
     trajectory = trajectory[:, readout_mask, :]
     trajectory = trajectory.reshape((-1, Ns_readouts, Nd))
     return trajectory
-
-
-def _trapezoidal_area(gs, ge, gi, n_down, n_up, n_pl):
-    """Calculate the area traversed by the trapezoidal gradient waveform."""
-    return 0.5 * (gs + gi) * (n_down + 1) + 0.5 * (ge + gi) * (n_up - 1) + n_pl * gi
-
-
-def _trapezoidal_plateau_length(
-    gs, ge, gi, n_down, n_up, area_needed, ceil=False, buffer=0
-):
-    """Calculate the plateau length of the trapezoidal gradient waveform."""
-    n_pl = (
-        0.5
-        * (2 * area_needed - gs * (n_down + 1) - ge * (n_up - 1) + gi * (n_down + n_up))
-        / (gi + np.finfo(gi.dtype).eps)
-    )
-    if ceil:
-        n_pl = np.ceil(n_pl).astype(int)
-    return n_pl + buffer
-
-
-def _trapezoidal_ramps(gs, ge, gi, smax, raster_time, ceil=False, buffer=0):
-    """Calculate the number of time steps for the ramp down and up."""
-    n_ramp_down = np.abs(gi - gs) / (smax * raster_time)
-    n_ramp_up = np.abs(ge - gi) / (smax * raster_time)
-    if ceil:
-        n_ramp_down = np.ceil(n_ramp_down).astype(int)
-        n_ramp_up = np.ceil(n_ramp_up).astype(int)
-    return n_ramp_down + buffer, n_ramp_up + buffer
-
-
-def _plateau_value(gs, ge, n_down, n_up, n_pl, area_needed):
-    """Calculate the  value of the plateau of a trapezoidal gradient waveform."""
-    return (2 * area_needed - (n_down + 1) * gs - (n_up - 1) * ge) / (
-        n_down + n_up + 2 * n_pl
-    )
-
-
-def get_gradient_times_to_travel(
-    kspace_end_loc: NDArray | None = None,
-    kspace_start_loc: NDArray | None = None,
-    end_gradients: NDArray | None = None,
-    start_gradients: NDArray | None = None,
-    acq: Acquisition | None = None,
-    n_jobs: int = 1,
-) -> tuple[NDArray, NDArray, NDArray, NDArray]:
-    """Get gradient timing values for trapezoidal or triangular waveforms.
-
-    Compute gradient timing values to take k-space trajectories
-    from position ``ks`` with gradient ``gs`` to position ``ke`` with gradient
-    ``ge``, while being hardware compliant.
-    This function calculates the minimal number of time steps required for
-    the ramp down, ramp up, and plateau phases of the gradient waveform,
-    ensuring that the area traversed in k-space matches the desired
-    trajectory while adhering to the maximum gradient amplitude and
-    slew rate constraints.
-
-    Parameters
-    ----------
-    kspace_end_loc : NDArray
-        Ending k-space positions, shape (nb_shots, nb_dimension).
-    kspace_start_loc : NDArray, default None when it is 0
-        Starting k-space positions, shape (nb_shots, nb_dimension).
-    end_gradients : NDArray, default None when it is 0
-        Ending gradient values, shape (nb_shots, nb_dimension).
-    start_gradients : NDArray, default None when it is 0
-        Starting gradient values, shape (nb_shots, nb_dimension).
-    acq : Acquisition, optional
-        Acquisition configuration to use.
-        If `None`, the default acquisition is used.
-    n_jobs : int, optional
-        Number of parallel jobs to run for optimization, by default 1.
-
-    Returns
-    -------
-    n_ramp_down: The timing values for the ramp down phase.
-    n_ramp_up: The timing values for the ramp up phase.
-    n_plateau: The timing values for the plateau phase.
-    gi: The intermediate gradient values for trapezoidal or triangular waveforms.
-
-    See Also
-    --------
-    get_gradient_amplitudes_to_travel_for_set_time :
-        To directly get the waveforms required. This is most-likely what
-        you want to use.
-    """
-    acq = acq or Acquisition.default
-    area_needed = (kspace_end_loc - kspace_start_loc) / acq.gamma / acq.raster_time
-
-    def solve_gi_min_plateau(gs, ge, area):
-        def _residual(gi):
-            n_down, n_up = _trapezoidal_ramps(gs, ge, gi, acq.smax, acq.raster_time)
-            n_pl = _trapezoidal_plateau_length(gs, ge, gi, n_down, n_up, area)
-            if n_pl < 0:
-                return np.abs(n_pl) * 10000  # Penalize negative plateau
-            return n_pl * 100  # Penalize large plateau
-
-        res = minimize_scalar(
-            _residual,
-            bounds=(-acq.gmax, acq.gmax),
-            method="bounded",
-        )
-        if not res.success:
-            raise RuntimeError(f"Minimization failed: {res.message}")
-        return res.x
-
-    gi = Parallel(n_jobs=n_jobs)(
-        delayed(solve_gi_min_plateau)(
-            start_gradients[i, j],
-            end_gradients[i, j],
-            area_needed[i, j],
-        )
-        for i in range(start_gradients.shape[0])
-        for j in range(start_gradients.shape[1])
-    )
-    gi = np.array(gi).reshape(start_gradients.shape)
-    n_ramp_down, n_ramp_up = _trapezoidal_ramps(
-        start_gradients,
-        end_gradients,
-        gi,
-        acq.smax,
-        acq.raster_time,
-        ceil=True,
-        buffer=1,
-    )
-    n_plateau = _trapezoidal_plateau_length(
-        start_gradients,
-        end_gradients,
-        gi,
-        n_ramp_down,
-        n_ramp_up,
-        area_needed,
-        ceil=True,
-    )
-    return n_ramp_down, n_ramp_up, n_plateau, gi
-
-
-def get_gradient_amplitudes_to_travel_for_set_time(
-    kspace_end_loc: NDArray,
-    kspace_start_loc: NDArray | None = None,
-    end_gradients: NDArray | None = None,
-    start_gradients: NDArray | None = None,
-    nb_raster_points: int | None = None,
-    acq: Acquisition | None = None,
-    n_jobs: int = 1,
-) -> NDArray:
-    """Calculate timings for trapezoidal or triangular gradient waveforms.
-
-    Compute the gradient waveforms required to traverse from a starting k-space
-    position ``ks`` to an ending k-space position ``ke`` in a fixed number of time
-    steps ``N``, subject to hardware constraints on maximum gradient amplitude
-    ``gmax`` and slew rate ``smax``. The function supports both trapezoidal
-    and triangular gradient shapes, automatically adjusting the waveform to
-    meet the area constraint imposed by the desired k-space traversal
-    and the specified timing and hardware limits.
-
-    Parameters
-    ----------
-    kspace_end_loc : NDArray
-        Ending k-space positions, shape (nb_shots, nb_dimension).
-    kspace_start_loc : NDArray, default None when it is 0
-        Starting k-space positions, shape (nb_shots, nb_dimension).
-    end_gradients : NDArray, default None when it is 0
-        Ending gradient values, shape (nb_shots, nb_dimension).
-    start_gradients : NDArray, default None when it is 0
-        Starting gradient values, shape (nb_shots, nb_dimension).
-    nb_raster_points : int, default None
-        Number of time steps (samples) for the gradient waveform.
-        If None, timing is calculated based on the area needed and hardware limits.
-    acq : Acquisition, optional
-        Acquisition configuration to use.
-        If `None`, the default acquisition is used.
-    n_jobs : int, optional
-        Number of parallel jobs to run for optimization, by default 1.
-
-    Returns
-    -------
-    NDArray
-        Gradient waveforms, shape (nb_shots, nb_samples_per_shot, nb_dimension),
-        where each entry contains the gradient value at each time step for each shot
-        and dimension.
-
-    Notes
-    -----
-    - The function automatically determines whether a trapezoidal or triangular waveform
-      is needed based on the area constraint and hardware limits.
-    - The returned gradients are suitable for use in MRI pulse sequence design,
-      ensuring compliance with specified hardware constraints.
-    """
-    acq = acq or Acquisition.default
-
-    kspace_end_loc = np.atleast_2d(kspace_end_loc)
-    if kspace_start_loc is None:
-        kspace_start_loc = np.zeros_like(kspace_end_loc)
-    if start_gradients is None:
-        start_gradients = np.zeros_like(kspace_end_loc)
-    if end_gradients is None:
-        end_gradients = np.zeros_like(kspace_end_loc)
-    kspace_start_loc = np.atleast_2d(kspace_start_loc)
-    start_gradients = np.atleast_2d(start_gradients)
-    end_gradients = np.atleast_2d(end_gradients)
-
-    assert (
-        kspace_start_loc.shape
-        == kspace_end_loc.shape
-        == start_gradients.shape
-        == end_gradients.shape
-    ), "All input arrays must have shape (nb_shots, nb_dimension)"
-    if nb_raster_points is None:
-        # Calculate the number of time steps based on the area needed
-        n_ramp_down, n_ramp_up, n_plateau, gi = get_gradient_times_to_travel(
-            kspace_end_loc=kspace_end_loc,
-            kspace_start_loc=kspace_start_loc,
-            end_gradients=end_gradients,
-            start_gradients=start_gradients,
-            acq=acq,
-        )
-        # Extra 2 buffer samples
-        nb_raster_points = int(np.max(n_ramp_down + n_ramp_up + n_plateau) + 2)
-
-    area_needed = (kspace_end_loc - kspace_start_loc) / acq.gamma / acq.raster_time
-
-    def solve_gi_fixed_N(gs, ge, area):
-        def _residual(gi):
-            n_down, n_up = _trapezoidal_ramps(
-                gs, ge, gi, acq.smax, acq.raster_time, buffer=1
-            )
-            n_pl = nb_raster_points - n_down - n_up
-            if n_pl < 0:
-                return np.abs(n_pl)  # Penalize this
-            area_expr = _trapezoidal_area(gs, ge, gi, n_down, n_up, n_pl)
-            return np.abs(area - area_expr)
-
-        res = minimize_scalar(
-            _residual,
-            bounds=(-acq.gmax, acq.gmax),
-            method="bounded",
-            options={"xatol": 1e-10},
-        )
-        if not res.success:
-            raise RuntimeError(f"Minimization failed: {res.message}")
-        return res.x
-
-    gi = Parallel(n_jobs=n_jobs)(
-        delayed(solve_gi_fixed_N)(
-            start_gradients[i, j],
-            end_gradients[i, j],
-            area_needed[i, j],
-        )
-        for i in range(start_gradients.shape[0])
-        for j in range(start_gradients.shape[1])
-    )
-    gi = np.array(gi).reshape(start_gradients.shape)
-    n_ramp_down, n_ramp_up = _trapezoidal_ramps(
-        start_gradients,
-        end_gradients,
-        gi,
-        acq.smax,
-        acq.raster_time,
-        ceil=True,
-    )
-    n_plateau = nb_raster_points - n_ramp_down - n_ramp_up
-    gi = _plateau_value(
-        start_gradients, end_gradients, n_ramp_down, n_ramp_up, n_plateau, area_needed
-    )
-    nb_shots, nb_dimension = kspace_end_loc.shape
-    G = np.zeros((nb_shots, nb_raster_points, nb_dimension), dtype=np.float32)
-    for i in range(nb_shots):
-        for d in range(nb_dimension):
-            start = 0
-            G[i, : n_ramp_down[i, d], d] = np.linspace(
-                start_gradients[i, d], gi[i, d], n_ramp_down[i, d], endpoint=False
-            )
-            start += n_ramp_down[i, d]
-            if n_plateau[i, d] > 0:
-                G[i, start : start + n_plateau[i, d], d] = gi[i, d]
-                start += n_plateau[i, d]
-            G[i, start : start + n_ramp_up[i, d], d] = np.linspace(
-                gi[i, d], end_gradients[i, d], n_ramp_up[i, d], endpoint=False
-            )
-    return G
 
 
 def prewind(trajectory: NDArray, Ns_transitions: int) -> NDArray:
@@ -1119,9 +835,9 @@ def get_random_loc_1d(
     dim_size: int,
     center_prop: float | int,
     accel: float = 4,
-    pdf: Literal["uniform", "gaussian", "equispaced"] | NDArray = "uniform",
+    pdf: Literal["uniform", "gaussian", "equispaced"] | NDArray | VDSpdf = "uniform",
     rng: int | np.random.Generator | None = None,
-    order: Literal["center-out", "top-down", "random"] = "center-out",
+    order: Literal["center-out", "top-down", "random"] | VDSorder = "center-out",
 ) -> NDArray:
     """Get slice index at a random position.
 
@@ -1172,7 +888,7 @@ def get_random_loc_1d(
         )
     rng = np.random.default_rng(rng)  # get RNG from a seed or existing rng.
 
-    def _get_samples(p: np.typing.ArrayLike) -> list[int]:
+    def _get_samples(p: NDArray) -> list[int]:
         p = p / np.sum(p)  # automatic casting if needed
         return list(rng.choice(borders, size=n_samples_borders, replace=False, p=p))
 
@@ -1331,7 +1047,7 @@ def get_grappa_caipi_positions(
             np.asarray(
                 np.meshgrid(
                     *[
-                        np.linspace(-max_loc, max_loc, num, endpoint=num % 2)
+                        np.linspace(-max_loc, max_loc, num, endpoint=num % 2)  # type: ignore
                         for num, max_loc in zip(acs_region, acs_max_loc)
                     ],
                     indexing="ij",
@@ -1383,7 +1099,7 @@ def get_packing_spacing_positions(
     if packing_enum == Packings.RANDOM:
         positions = 2 * side * (np.random.random((side * side, 2)) - 0.5)
     elif packing_enum == Packings.CIRCLE:
-        positions = [[0, 0]]
+        positions = np.zeros((1, 2))
         counter = 0
         while len(positions) < side**2:
             counter += 1
@@ -1392,7 +1108,7 @@ def get_packing_spacing_positions(
             # Add the full circle
             radius = 2 * counter
             angles = 2 * np.pi * np.arange(nb_shots) / nb_shots
-            circle = radius * np.exp(1j * angles)
+            circle: NDArray[np.complexfloating] = radius * np.exp(1j * angles)
             positions = np.concatenate(
                 [positions, np.array([circle.real, circle.imag]).T], axis=0
             )
@@ -1402,6 +1118,7 @@ def get_packing_spacing_positions(
             np.arange(-side + 1, side, 2), np.arange(-side + 1, side, 2)
         )
         positions = np.stack([px.flatten(), py.flatten()], axis=-1).astype(float)
+
     if packing_enum in [Packings.HEXAGON, Packings.TRIANGLE]:
         # Hexagonal/triangular packing based on square packing
         positions[::2, 1] += 1 / 2

--- a/src/mrinufft/trajectories/trajectory3D.py
+++ b/src/mrinufft/trajectories/trajectory3D.py
@@ -505,6 +505,8 @@ def initialize_3D_wave_caipi(
             / np.pi
             / nb_revolutions
         )  # Extra factor from angles
+        if np.isscalar(width):
+            width = (width, width, width)
         width = tuple(w for i, w in enumerate(width) if i != readout_axis)
     else:
         width = (width, width) if np.isscalar(width) else width

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -408,7 +408,9 @@ def normalize_trajectory(
         Normalized trajectory corresponding to `trajectory` input.
     """
     acq = acq or Acquisition.default
-    return trajectory * acq.norm_factor * (2 * np.array(acq.res))
+    return (
+        trajectory * acq.norm_factor * (2 * np.array(acq.res[: trajectory.shape[-1]]))
+    )
 
 
 def unnormalize_trajectory(


### PR DESCRIPTION
- Closes #102
- Closes #262 
- Closes #286
- Closes #270

Changes proposed in this pull request:

- [x] Add a reader for pulseq sequences to extract kspace trajectories (formatted to MRI-nufft conventions) from pulseq files
   - That would make for a nice functional test `traj -> write_seq -> read_seq -> compare`.
- ~~( Add a helper function to create gradients block for pypulseq)~~
   -  there is now a `prepare_trajectory_for_seq` that creates gradients waveforms with pre/re-winders. Generating the gradients event directly does not make much sense I feel. 
- [x] Add a simple generation of a GRE sequence with pypulseq.


