### PR TITLE
Acquisition Configuration

### DIFF
--- a/examples/GPU/example_3d_trajectory_display.py
+++ b/examples/GPU/example_3d_trajectory_display.py
@@ -14,13 +14,20 @@ Another key feature is to display the sampling density in k-space, for example t
 import os
 from mrinufft.trajectories.display3D import get_gridded_trajectory
 import mrinufft.trajectories.trajectory3D as mtt
-from mrinufft.trajectories.utils import Gammas
+from mrinufft.trajectories.utils import Gammas, Acquisition
 import matplotlib.pyplot as plt
 import numpy as np
 
 
 BACKEND = os.environ.get("MRINUFFT_BACKEND", "gpunufft")
 
+
+# %%
+# Acquisition parameters
+# ======================
+# Here we use acquisition defaults for the  trajectory gridding.
+
+acq = Acquisition.default
 
 # %%
 # Helper function to Displaying 3D Gridded Trajectories
@@ -57,9 +64,8 @@ def create_grid(grid_type, trajectories, traj_params, **kwargs):
     for i, (name, traj) in enumerate(trajectories.items()):
         grid = get_gridded_trajectory(
             traj,
-            traj_params["img_size"],
+            acq,
             grid_type=grid_type,
-            traj_params=traj_params,
             backend=BACKEND,
             osf=2,
             **kwargs,

--- a/examples/GPU/example_3d_trajectory_display.py
+++ b/examples/GPU/example_3d_trajectory_display.py
@@ -29,6 +29,7 @@ BACKEND = os.environ.get("MRINUFFT_BACKEND", "gpunufft")
 
 acq = Acquisition.default
 
+
 # %%
 # Helper function to Displaying 3D Gridded Trajectories
 # =====================================================

--- a/examples/operators/example_offresonance.py
+++ b/examples/operators/example_offresonance.py
@@ -88,7 +88,7 @@ from mrinufft.density import voronoi
 from mrinufft.trajectories.utils import Acquisition
 
 samples = initialize_2D_spiral(Nc=48, Ns=600, nb_revolutions=10)
-t_read = np.arange(samples.shape[1]) * Acquisition.raster_time
+t_read = np.arange(samples.shape[1]) * Acquisition.default.raster_time
 t_read = np.repeat(t_read[None, ...], samples.shape[0], axis=0)
 density = voronoi(samples)
 

--- a/examples/operators/example_offresonance.py
+++ b/examples/operators/example_offresonance.py
@@ -85,10 +85,10 @@ plt.show()
 
 from mrinufft import initialize_2D_spiral
 from mrinufft.density import voronoi
-from mrinufft.trajectories.utils import DEFAULT_RASTER_TIME
+from mrinufft.trajectories.utils import Acquisition
 
 samples = initialize_2D_spiral(Nc=48, Ns=600, nb_revolutions=10)
-t_read = np.arange(samples.shape[1]) * DEFAULT_RASTER_TIME * 1e-3
+t_read = np.arange(samples.shape[1]) * Acquisition.raster_time
 t_read = np.repeat(t_read[None, ...], samples.shape[0], axis=0)
 density = voronoi(samples)
 

--- a/examples/trajectories/example_3D_trajectories.py
+++ b/examples/trajectories/example_3D_trajectories.py
@@ -30,7 +30,6 @@ from utils import show_trajectories, show_trajectory
 
 # Internal
 import mrinufft as mn
-from mrinufft import display_2D_trajectory, display_3D_trajectory
 
 # %%
 # Script options

--- a/examples/trajectories/example_display_config.py
+++ b/examples/trajectories/example_display_config.py
@@ -141,9 +141,11 @@ acqs = [
     ),
 ]  # limiting slew rate to 200 T/m/s
 
-show_traj(
-    traj,
-    "acq",
-    acqs,
-    show_constraints=True,
-)
+# you can use Acquisition as a Context Manager, like display config.
+# Or pass it to the display function as well.
+for acq in acqs:
+    with acq:
+        display_3D_trajectory(traj, show_constraints=True)
+
+    # equivalent to
+    # display_3D_trajectory(traj, show_constraints=True, acq=acq)

--- a/examples/trajectories/example_display_config.py
+++ b/examples/trajectories/example_display_config.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from mrinufft import display_2D_trajectory, display_3D_trajectory, displayConfig
 from mrinufft.trajectories import conify, initialize_2D_spiral
-from mrinuff.trajectories.utils import Acquisition, Hardware
+from mrinufft.trajectories.utils import Acquisition, Hardware
 
 # %%
 # Script options
@@ -124,9 +124,9 @@ show_traj(
 # violations change.
 #
 acqs = [
-    Acquisition(Hardware(gmax=0.04, smax=50)),  # limiting slew rate to 50 T/m/s
-    Acquisition(Hardware(gmax=0.04, smax=100)),  # limiting slew rate to 100 T/m/s
-    Acquisition(Hardware(gmax=0.04, smax=200)),
+    Acquisition(fov=(0.256,0.256,0.256), img_size=(256,256,256), hardware=Hardware(gmax=0.04, smax=50)),  # limiting slew rate to 50 T/m/s
+    Acquisition(fov=(0.256,0.256,0.256), img_size=(256,256,256), hardware=Hardware(gmax=0.04, smax=100)),  # limiting slew rate to 100 T/m/s
+    Acquisition(fov=(0.256,0.256,0.256), img_size=(256,256,256), hardware=Hardware(gmax=0.04, smax=200)),
 ]  # limiting slew rate to 200 T/m/s
 
 show_traj(

--- a/examples/trajectories/example_display_config.py
+++ b/examples/trajectories/example_display_config.py
@@ -124,9 +124,21 @@ show_traj(
 # violations change.
 #
 acqs = [
-    Acquisition(fov=(0.256,0.256,0.256), img_size=(256,256,256), hardware=Hardware(gmax=0.04, smax=50)),  # limiting slew rate to 50 T/m/s
-    Acquisition(fov=(0.256,0.256,0.256), img_size=(256,256,256), hardware=Hardware(gmax=0.04, smax=100)),  # limiting slew rate to 100 T/m/s
-    Acquisition(fov=(0.256,0.256,0.256), img_size=(256,256,256), hardware=Hardware(gmax=0.04, smax=200)),
+    Acquisition(
+        fov=(0.256, 0.256, 0.256),
+        img_size=(256, 256, 256),
+        hardware=Hardware(gmax=0.04, smax=50),
+    ),  # limiting slew rate to 50 T/m/s
+    Acquisition(
+        fov=(0.256, 0.256, 0.256),
+        img_size=(256, 256, 256),
+        hardware=Hardware(gmax=0.04, smax=100),
+    ),  # limiting slew rate to 100 T/m/s
+    Acquisition(
+        fov=(0.256, 0.256, 0.256),
+        img_size=(256, 256, 256),
+        hardware=Hardware(gmax=0.04, smax=200),
+    ),
 ]  # limiting slew rate to 200 T/m/s
 
 show_traj(

--- a/examples/trajectories/example_display_config.py
+++ b/examples/trajectories/example_display_config.py
@@ -16,6 +16,7 @@ import numpy as np
 from mrinufft import display_2D_trajectory, display_3D_trajectory, displayConfig
 from mrinufft.trajectories import conify, initialize_2D_spiral
 from mrinuff.trajectories.utils import Acquisition, Hardware
+
 # %%
 # Script options
 # ==============
@@ -122,9 +123,11 @@ show_traj(
 # You can also change the values of gmax and smax in order to see how the constraint
 # violations change.
 #
-acqs = [Acquisition(Hardware(gmax=0.04, smax=50)), # limiting slew rate to 50 T/m/s
-        Acquisition(Hardware(gmax=0.04, smax=100)), # limiting slew rate to 100 T/m/s
-        Acquisition(Hardware(gmax=0.04, smax=200)),] # limiting slew rate to 200 T/m/s
+acqs = [
+    Acquisition(Hardware(gmax=0.04, smax=50)),  # limiting slew rate to 50 T/m/s
+    Acquisition(Hardware(gmax=0.04, smax=100)),  # limiting slew rate to 100 T/m/s
+    Acquisition(Hardware(gmax=0.04, smax=200)),
+]  # limiting slew rate to 200 T/m/s
 
 show_traj(
     traj,

--- a/examples/trajectories/example_display_config.py
+++ b/examples/trajectories/example_display_config.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from mrinufft import display_2D_trajectory, display_3D_trajectory, displayConfig
 from mrinufft.trajectories import conify, initialize_2D_spiral
-
+from mrinuff.trajectories.utils import Acquisition, Hardware
 # %%
 # Script options
 # ==============
@@ -116,5 +116,19 @@ show_traj(
     traj,
     "slewrate_point_color",
     ["tab:blue", "tab:orange", "tab:red"],
+    show_constraints=True,
+)
+
+# You can also change the values of gmax and smax in order to see how the constraint
+# violations change.
+#
+acqs = [Acquisition(Hardware(gmax=0.04, smax=50)), # limiting slew rate to 50 T/m/s
+        Acquisition(Hardware(gmax=0.04, smax=100)), # limiting slew rate to 100 T/m/s
+        Acquisition(Hardware(gmax=0.04, smax=200)),] # limiting slew rate to 200 T/m/s
+
+show_traj(
+    traj,
+    "acq",
+    acqs,
     show_constraints=True,
 )

--- a/examples/trajectories/utils.py
+++ b/examples/trajectories/utils.py
@@ -16,7 +16,7 @@ from mrinufft.trajectories.utils import KMAX
 def show_trajectory(trajectory, one_shot, figure_size):
     if trajectory.shape[-1] == 2:
         ax = display_2D_trajectory(
-            trajectory, size=figure_size, one_shot=one_shot % trajectory.shape[0]
+            trajectory, figsize=figure_size, one_shot=one_shot % trajectory.shape[0]
         )
         ax.set_aspect("equal")
         plt.tight_layout()
@@ -24,7 +24,7 @@ def show_trajectory(trajectory, one_shot, figure_size):
     else:
         ax = display_3D_trajectory(
             trajectory,
-            size=figure_size,
+            figsize=figure_size,
             one_shot=one_shot % trajectory.shape[0],
             per_plane=False,
         )
@@ -49,7 +49,7 @@ def show_trajectories(
         if dim == "3D" and traj.shape[-1] == 3:
             ax = display_3D_trajectory(
                 traj,
-                size=subfig_size,
+                figsize=subfig_size,
                 one_shot=one_shot % traj.shape[0],
                 subfigure=subfig,
                 per_plane=False,
@@ -57,7 +57,7 @@ def show_trajectories(
         else:
             ax = display_2D_trajectory(
                 traj[..., axes],
-                size=subfig_size,
+                figsize=subfig_size,
                 one_shot=one_shot % traj.shape[0],
                 subfigure=subfig,
             )

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -326,7 +326,7 @@ def write_trajectory(
 
 def read_trajectory(
     grad_filename: str,
-    dwell_time: float | str = Acquisition.default.dwell_time,
+    dwell_time: float | str = Acquisition.default.adc_dwell_time,
     num_adc_samples: int | None = None,
     gamma: Gammas | float = Acquisition.default.gamma,
     raster_time: float = Acquisition.default.raster_time,

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -331,7 +331,7 @@ def read_trajectory(
     gamma: Gammas | float = Acquisition.default.gamma,
     raster_time: float = Acquisition.default.raster_time,
     read_shots: bool = False,
-    normalize_factor: float = Acquisition.default.normalize_factor,
+    normalize_factor: float = Acquisition.default.norm_factor,
     pre_skip: int = 0,
 ):
     """Get k-space locations from gradient file.

--- a/src/mrinufft/io/nsp.py
+++ b/src/mrinufft/io/nsp.py
@@ -18,7 +18,10 @@ from mrinufft.trajectories.utils import (
     check_hardware_constraints,
     convert_gradients_to_slew_rates,
     convert_trajectory_to_gradients,
-    DEFAULT_GMAX,DEFAULT_SMAX, KMAX, DEFAULT_RASTER_TIME
+    DEFAULT_GMAX,
+    DEFAULT_SMAX,
+    KMAX,
+    DEFAULT_RASTER_TIME,
 )
 from mrinufft.trajectories.tools import get_gradient_amplitudes_to_travel_for_set_time
 
@@ -211,7 +214,7 @@ def write_trajectory(
     img_size: tuple[int, ...],
     grad_filename: str,
     norm_factor: float = KMAX,
-    gamma: float = Gammas.HYDROGEN/1e3,
+    gamma: float = Gammas.HYDROGEN / 1e3,
     raster_time: float = DEFAULT_RASTER_TIME,
     check_constraints: bool = True,
     TE_pos: float = 0.5,
@@ -275,7 +278,7 @@ def write_trajectory(
         img_size=img_size,
         gamma=gamma,
         norm_factor=norm_factor,
-        hardware=Hardware(gmax=gmax, smax=smax, grad_raster_time=raster_time)
+        hardware=Hardware(gmax=gmax, smax=smax, grad_raster_time=raster_time),
     )
     gradients, initial_positions, final_positions = convert_trajectory_to_gradients(
         trajectory,

--- a/src/mrinufft/trajectories/display.py
+++ b/src/mrinufft/trajectories/display.py
@@ -390,8 +390,12 @@ def display_3D_trajectory(
         )
 
         # Check constraints
-        gradients = trajectory.reshape((-1, 3))[np.where(gradients.flatten() > acq.gmax)]
-        slewrates = trajectory.reshape((-1, 3))[np.where(slewrates.flatten() > acq.smax)]
+        gradients = trajectory.reshape((-1, 3))[
+            np.where(gradients.flatten() > acq.gmax)
+        ]
+        slewrates = trajectory.reshape((-1, 3))[
+            np.where(slewrates.flatten() > acq.smax)
+        ]
 
         # Scatter points with vivid colors
         ax.scatter(

--- a/src/mrinufft/trajectories/display.py
+++ b/src/mrinufft/trajectories/display.py
@@ -347,6 +347,8 @@ def display_3D_trajectory(
         Axes of the figure.
     """
     # Setup figure and ticks, and handle 2D trajectories
+    acq = acq or Acquisition.default
+
     ax = _setup_3D_ticks(figsize, subfigure)
     if nb_repetitions is None:
         nb_repetitions = trajectory.shape[0]

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -461,7 +461,6 @@ def get_gradient_times_to_travel(
         To directly get the waveforms required. This is most-likely what
         you want to use.
     """
-
     acq = acq or Acquisition.default
     area_needed = (kspace_end_loc - kspace_start_loc) / acq.gamma / acq.raster_time
 
@@ -565,8 +564,6 @@ def get_gradient_amplitudes_to_travel_for_set_time(
     - The returned gradients are suitable for use in MRI pulse sequence design,
       ensuring compliance with specified hardware constraints.
     """
-
-
     acq = acq or Acquisition.default
 
     kspace_end_loc = np.atleast_2d(kspace_end_loc)

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -596,7 +596,9 @@ def get_gradient_amplitudes_to_travel_for_set_time(
 
     def solve_gi_fixed_N(gs, ge, area):
         def _residual(gi):
-            n_down, n_up = _trapezoidal_ramps(gs, ge, gi, acq.smax, acq.raster_time, buffer=1)
+            n_down, n_up = _trapezoidal_ramps(
+                gs, ge, gi, acq.smax, acq.raster_time, buffer=1
+            )
             n_pl = nb_raster_points - n_down - n_up
             if n_pl < 0:
                 return np.abs(n_pl)  # Penalize this
@@ -604,7 +606,10 @@ def get_gradient_amplitudes_to_travel_for_set_time(
             return np.abs(area - area_expr)
 
         res = minimize_scalar(
-            _residual, bounds=(-acq.gmax, acq.gmax), method="bounded", options={"xatol": 1e-10}
+            _residual,
+            bounds=(-acq.gmax, acq.gmax),
+            method="bounded",
+            options={"xatol": 1e-10},
         )
         if not res.success:
             raise RuntimeError(f"Minimization failed: {res.message}")

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -461,6 +461,8 @@ def get_gradient_times_to_travel(
         To directly get the waveforms required. This is most-likely what
         you want to use.
     """
+
+    acq = acq or Acquisition.default
     area_needed = (kspace_end_loc - kspace_start_loc) / acq.gamma / acq.raster_time
 
     def solve_gi_min_plateau(gs, ge, area):
@@ -563,6 +565,10 @@ def get_gradient_amplitudes_to_travel_for_set_time(
     - The returned gradients are suitable for use in MRI pulse sequence design,
       ensuring compliance with specified hardware constraints.
     """
+
+
+    acq = acq or Acquisition.default
+
     kspace_end_loc = np.atleast_2d(kspace_end_loc)
     if kspace_start_loc is None:
         kspace_start_loc = np.zeros_like(kspace_end_loc)

--- a/src/mrinufft/trajectories/tools.py
+++ b/src/mrinufft/trajectories/tools.py
@@ -415,10 +415,10 @@ def _plateau_value(gs, ge, n_down, n_up, n_pl, area_needed):
 
 
 def get_gradient_times_to_travel(
-    kspace_end_loc: Optional[NDArray] = None,
-    kspace_start_loc: Optional[NDArray] = None,
-    end_gradients: Optional[NDArray] = None,
-    start_gradients: Optional[NDArray] = None,
+    kspace_end_loc: NDArray | None = None,
+    kspace_start_loc: NDArray | None = None,
+    end_gradients: NDArray | None = None,
+    start_gradients: NDArray | None = None,
     acq: Acquisition | None = None,
     n_jobs: int = 1,
 ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
@@ -515,10 +515,10 @@ def get_gradient_times_to_travel(
 
 def get_gradient_amplitudes_to_travel_for_set_time(
     kspace_end_loc: NDArray,
-    kspace_start_loc: Optional[NDArray] = None,
-    end_gradients: Optional[NDArray] = None,
-    start_gradients: Optional[NDArray] = None,
-    nb_raster_points: Optional[int] = None,
+    kspace_start_loc: NDArray | None = None,
+    end_gradients: NDArray | None = None,
+    start_gradients: NDArray | None = None,
+    nb_raster_points: int | None = None,
     acq: Acquisition | None = None,
     n_jobs: int = 1,
 ) -> NDArray:

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -244,7 +244,7 @@ class Hardware:
     smax: float = 200  # T/m/s
     n_coils: int = 32
     min_dwell_time: float = 1 * SI.nano  # s
-    grad_raster_time: float = 5 * SI.micro  # s
+    grad_raster_time: float = 10 * SI.micro  # s
     field_strength: float = 3.0  # Tesla
 
     @property

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -393,7 +393,7 @@ def normalize_trajectory(
         Normalized trajectory corresponding to `trajectory` input.
     """
     acq = acq or Acquisition.default
-    return trajectory * acq.norm_factor * (2 * acq.res)
+    return trajectory * acq.norm_factor * (2 * np.array(acq.res))
 
 
 def unnormalize_trajectory(
@@ -416,7 +416,7 @@ def unnormalize_trajectory(
         Un-normalized trajectory corresponding to `trajectory` input.
     """
     acq = acq or Acquisition.default
-    return trajectory / acq.norm_factor / (2 * acq.resolution)
+    return trajectory / acq.norm_factor / (2 * np.array(acq.res)[:trajectory.shape[-1]])
 
 
 def convert_trajectory_to_gradients(
@@ -440,7 +440,7 @@ def convert_trajectory_to_gradients(
     Returns
     -------
     gradients : NDArray
-        Gradients corresponding to `trajectory`.
+        Gradients corresponding to `trajectory` in T/m
     """
     acq = acq or Acquisition.default
     # Un-normalize the trajectory from NUFFT usage
@@ -464,7 +464,7 @@ def convert_gradients_to_trajectory(
     Parameters
     ----------
     gradients : NDArray
-        Gradients over 2 or 3 directions.
+        Gradients over 2 or 3 directions in T/m
     initial_positions: NDArray, optional
         Positions in k-space at the beginning of the readout window.
         The default is `None`.

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -252,6 +252,7 @@ class Hardware:
         """Alias of grad_raster_time."""
         return self.grad_raster_time
 
+
 # fmt: off
 class SIEMENS:
     """Common hardware configurations for Siemens MRI systems."""
@@ -264,6 +265,7 @@ class SIEMENS:
     CIMAX          = Hardware(gmax=200*SI.milli, smax=200, field_strength=3)
 
 # fmt: on
+
 
 @dataclass(frozen=True)
 class Acquisition:

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -203,8 +203,8 @@ class Hardware:
     gmax: float = 40 * SI.milli  # Maximum gradient amplitude in T/m
     smax: float = 200  # T/m/s
     n_coils: int = 8
-    dwell_time = 1 * SI.nano  # s
-    grad_raster_time = 5 * SI.micro  # s
+    dwell_time: float = 1 * SI.nano  # s
+    grad_raster_time: float = 5 * SI.micro  # s
     field_strength: float = 3.0  # Tesla
 
     @property

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -293,6 +293,7 @@ class Acquisition:
     default : ClassVar[Acquisition]
         The default acquisition configuration used if none is specified.
         You can set it using the `set_default` class method.
+
     Notes
     -----
     The `Acquisition` class encapsulates the parameters needed for MRI acquisition,
@@ -314,7 +315,7 @@ class Acquisition:
     img_size: tuple[int, int, int]  # Image size in pixels
     hardware: Hardware = SIEMENS.TERRA  # Hardware configuration
     gamma: Gammas = Gammas.HYDROGEN  # Hz/T
-    adc_dwell_time: float = 1 * SI.micro # us
+    adc_dwell_time: float = 1 * SI.micro  # us
     norm_factor: float = 0.5
 
     def __post_init__(self):
@@ -324,9 +325,9 @@ class Acquisition:
         if isinstance(self.img_size, int):
             self.img_size = (self.img_size, self.img_size, self.img_size)
 
-        if not(2 <= len(self.fov) <= 3):
+        if not (2 <= len(self.fov) <= 3):
             raise ValueError("fov must be a tuple of 3 elements (x, y, z).")
-        if not(2 <= len(self.img_size) <= 3):
+        if not (2 <= len(self.img_size) <= 3):
             raise ValueError("img_size must be a tuple of 3 elements (x, y, z).")
         if any(s <= 0 for s in self.img_size):
             raise ValueError("img_size must contain positive integers.")
@@ -350,15 +351,18 @@ class Acquisition:
     @property
     def res(self) -> tuple[float, ...]:
         """Resolution in meters."""
-        return tuple(fov / size for fov, size in zip(self.fov, self.img_size, strict=True))
-
+        return tuple(
+            fov / size for fov, size in zip(self.fov, self.img_size, strict=True)
+        )
 
     @property
     def kmax(self) -> tuple[float, ...]:
         """Maximum k-space value in 1/m."""
-        return tuple(0.5 * size / fov for fov, size in zip(self.fov, self.img_size, strict=True))
+        return tuple(
+            0.5 * size / fov for fov, size in zip(self.fov, self.img_size, strict=True)
+        )
 
-    
+
 # Create a default acquisition.
 Acquisition.default = Acquisition(
     fov=(0.256, 0.256, 0.256), img_size=(256, 256, 256), hardware=Hardware()

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -38,7 +38,7 @@ class CaseInsensitiveEnumMeta(EnumMeta):
 
     def __getattr__(self, name: str) -> Any:  # noqa ANN401
         """Allow ``MyEnum.Member == MyEnum.MEMBER`` ."""
-        return super().__getattr__(name.upper())
+        return super().__getattribute__(name.upper())
 
 
 class FloatEnum(float, Enum, metaclass=CaseInsensitiveEnumMeta):

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -362,6 +362,7 @@ class Acquisition:
             0.5 * size / fov for fov, size in zip(self.fov, self.img_size, strict=True)
         )
 
+
 # Create a default acquisition.
 Acquisition.default = Acquisition(
     fov=(0.256, 0.256, 0.256), img_size=(256, 256, 256), hardware=Hardware()
@@ -415,7 +416,9 @@ def unnormalize_trajectory(
         Un-normalized trajectory corresponding to `trajectory` input.
     """
     acq = acq or Acquisition.default
-    return trajectory / acq.norm_factor / (2 * np.array(acq.res)[:trajectory.shape[-1]])
+    return (
+        trajectory / acq.norm_factor / (2 * np.array(acq.res)[: trajectory.shape[-1]])
+    )
 
 
 def convert_trajectory_to_gradients(
@@ -492,9 +495,7 @@ def convert_gradients_to_trajectory(
 
 
 def convert_gradients_to_slew_rates(
-    gradients: NDArray,
-    acq: Acquisition | None = None,
-    raster_time: float |None=None
+    gradients: NDArray, acq: Acquisition | None = None, raster_time: float | None = None
 ) -> tuple[NDArray, NDArray]:
     """Derive the gradients over time to provide slew rates.
 

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -215,7 +215,7 @@ class Hardware:
     min_dwell_time : float
         Minimum ADC dwell time in seconds. Defaults to 1 ns.
     grad_raster_time : float
-        Gradient raster time in seconds. Defaults to 5 us.
+        Gradient raster time in seconds. Defaults to 10 us.
     field_strength : float
         Magnetic field strength in Tesla. Defaults to 3.0 T.
 
@@ -283,8 +283,8 @@ class Acquisition:
     gamma : Gammas, optional
         Gyromagnetic ratio in Hz/T for the nucleus being imaged.
         Defaults to `Gammas.HYDROGEN`.
-    oversampling : int, optional
-        Oversampling factor for the ADC. Defaults to 1.
+    adc_dwell_time: float
+        Time resolution for the ADC, in seconds. default to 5us.
     norm_factor : float, optional
         Normalization factor for the trajectory. Defaults to 0.5.
 
@@ -313,7 +313,7 @@ class Acquisition:
     img_size: tuple[int, int, int]  # Image size in pixels
     hardware: Hardware = SIEMENS.TERRA  # Hardware configuration
     gamma: Gammas = Gammas.HYDROGEN  # Hz/T
-    adc_dwell_time: float = 1 * SI.micro  # us
+    adc_dwell_time: float = 5 * SI.micro  # us
     norm_factor: float = 0.5
 
     default: ClassVar[Acquisition]

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -506,6 +506,8 @@ def convert_gradients_to_slew_rates(
     acq : Acquisition, optional
         Acquisition configuration to use.
         If `None`, the default acquisition is used.
+    raster_time: float
+        Raster time in seconds
 
     Returns
     -------
@@ -523,7 +525,7 @@ def convert_gradients_to_slew_rates(
         raster_time = Acquisition.default.raster_time
     else:
         raise ValueError("incompatible acquisition and raster_time")
-    slewrates = np.diff(gradients, axis=1) / acq.raster_time
+    slewrates = np.diff(gradients, axis=1) / raster_time
     initial_gradients = gradients[:, 0, :]
     return slewrates, initial_gradients
 

--- a/src/mrinufft/trajectories/utils.py
+++ b/src/mrinufft/trajectories/utils.py
@@ -292,7 +292,7 @@ class Acquisition:
     ----------
     default : ClassVar[Acquisition]
         The default acquisition configuration used if none is specified.
-
+        You can set it using the `set_default` class method.
     Notes
     -----
     The `Acquisition` class encapsulates the parameters needed for MRI acquisition,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -20,7 +20,7 @@ class CasesIO:
         trajectory = initialize_2D_radial(
             Nc=32, Ns=256, tilt="uniform", in_out=False
         ).astype(np.float32)
-        return "2D", trajectory, (0.23, 0.23), (256, 256), 0.5, 2, 42.576e3, 1.1
+        return "2D", trajectory, (0.23, 0.23), (256, 256), 0.5, 2, Gammas.H, 1.1
 
     def case_trajectory_3D(self):
         """Test the 3D Trajectory."""
@@ -41,7 +41,7 @@ class CasesIO:
 
 @fixture(scope="module")
 @parametrize("gmax", [0.1, Acquisition.default.gmax])
-@parametrize("smax", [0.7, Acquisition.default.smax])
+@parametrize("smax", [700, Acquisition.default.smax])
 def acquisition(gmax, smax):
     """Create a default acquisition object."""
     return Acquisition(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -81,7 +81,7 @@ def test_trajectory_state_changer_start(kspace_loc, shape, acquisition):
     assert np.all(np.abs(np.diff(GS, axis=1) / acq.raster_time) <= acq.smax)
     assert np.all(np.abs(GS[:, -1] - gradients[:, 0]) / acq.raster_time < acq.smax)
     if np.all(trajectory[:, 0] == 0):
-        # If the trajectory starts at the origin, we can check that the first gradient is zero
+        # trajectory starts at the origin, check that the first gradient is zero
         assert np.all(GS.shape[1] < 10)
     assert GS.shape[1] < 200  # Checks to ensure we don't have too many samples
     # Check that ending location matches.
@@ -107,6 +107,7 @@ def test_trajectory_state_changer_end(
     shape,
     acquisition,
 ):
+    """Test the trajectory state changer for the end of the trajectory."""
     acq = acquisition
     dimension = len(shape)
     resolution = dimension * (0.23 / 256,)
@@ -154,6 +155,7 @@ def test_write_n_read(
     postgrad,
     pregrad,
 ):
+    """Write the trajectory to a file and read it back."""
     if version < 5.1 and (postgrad is not None or pregrad is not None):
         pytest.skip("postgrad 'slowdown_to_edge' is not supported in version < 5.0")
     """Test function which writes the trajectory and reads it back."""


### PR DESCRIPTION
This PR introduces an Acquisition Configuration class, to help manage physical units relevant to MR system.

<!---
This is a suggested pull request template for mri-nufft.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://github.com/mind-inria/mri-nufft/blob/master/CONTRIBUTING.md) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #282
- Closes #257
- Open a clean path to #272, and all hardware dependent trajectories.
- There are some conflict with #283 , I will take care of it once we know which PR goes first.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Introduce the Acquisition class
- Update most of the functions (notable exception: `read_trajectory` in `io.nsp` module) that were relying on parameters such as `gmax`, `smax`, `raster_time` to use the acquisition object instead. 

This is a significant change (a lot of function signatures are modified), I would recommend a new release (2.0.0, including pulseq support). 
Note also that I tried to express all physical quantities in raw SI units (a.k.a. no kHz/G/cm)

TODO:

- [ ] Update test to use Acquisition as well 
- [ ] Add a doc file about the Acquisition 
- [ ] Add hardware configuration for well-known scanners (contribution welcome !)