### PR TITLE
Added support for multi-GPU runs with extra optional  in kwargs for both cufinufft and gpunufft operators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 
-gpunufft = ["gpuNUFFT>=0.9.0", "cupy-cuda12x"]
+gpunufft = ["gpuNUFFT>=0.10.1", "cupy-cuda12x"]
 
 torchkbnufft = ["torchkbnufft", "cupy-cuda12x"]
 torchkbnufft-cpu = ["torchkbnufft", "cupy-cuda12x"]

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -194,12 +194,14 @@ class MRICufiNUFFT(FourierOperatorBase):
             raise RuntimeError("cupy is not installed")
         if not CUFINUFFT_AVAILABLE:
             raise RuntimeError("Failed to found cufinufft binary.")
-        # set CUDA device 
+        # set CUDA device
         gpu_device_id = kwargs.get("gpu_device_id", 0)
         try:
             cp.cuda.Device(gpu_device_id).use()
         except Exception as e:
-            warnings.warn(f"Failed to set CUDA device {gpu_device_id}: {e}", RuntimeWarning)
+            warnings.warn(
+                f"Failed to set CUDA device {gpu_device_id}: {e}", RuntimeWarning
+            )
         super().__init__()
         if (n_batchs * n_coils) % n_trans != 0:
             raise ValueError("n_batchs * n_coils should be a multiple of n_transf")

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -194,7 +194,12 @@ class MRICufiNUFFT(FourierOperatorBase):
             raise RuntimeError("cupy is not installed")
         if not CUFINUFFT_AVAILABLE:
             raise RuntimeError("Failed to found cufinufft binary.")
-
+        # set CUDA device 
+        gpu_device_id = kwargs.get("gpu_device_id", 0)
+        try:
+            cp.cuda.Device(gpu_device_id).use()
+        except Exception as e:
+            warnings.warn(f"Failed to set CUDA device {gpu_device_id}: {e}", RuntimeWarning)
         super().__init__()
         if (n_batchs * n_coils) % n_trans != 0:
             raise ValueError("n_batchs * n_coils should be a multiple of n_transf")

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -119,7 +119,7 @@ class RawGpuNUFFT:
             In this case pinned memory is not used and this saved memory.
             It will not be an error if this is False and you pass GPU array,
             just that it is inefficient.
-        **kwargs (optional): additional arguments. These include 
+        **kwargs (optional): additional arguments. These include
             ``gpu_device_id``(GPU ID)
 
         Notes

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -83,7 +83,7 @@ class RawGpuNUFFT:
         pinned_image=None,
         pinned_kspace=None,
         use_gpu_direct=False,
-        **kwargs
+        **kwargs,
     ):
         """Initialize the 'NUFFT' class.
 
@@ -119,7 +119,8 @@ class RawGpuNUFFT:
             In this case pinned memory is not used and this saved memory.
             It will not be an error if this is False and you pass GPU array,
             just that it is inefficient.
-        **kwargs (optional): additional arguments. These include ``gpu_device_id``(GPU ID)
+        **kwargs (optional): additional arguments. These include 
+            ``gpu_device_id``(GPU ID)
 
         Notes
         -----
@@ -184,7 +185,7 @@ class RawGpuNUFFT:
             sector_width,
             osf,
             balance_workload,
-            **kwargs
+            **kwargs,
         )
 
     def toggle_grad_traj(self):

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -83,6 +83,7 @@ class RawGpuNUFFT:
         pinned_image=None,
         pinned_kspace=None,
         use_gpu_direct=False,
+        **kwargs
     ):
         """Initialize the 'NUFFT' class.
 
@@ -118,6 +119,7 @@ class RawGpuNUFFT:
             In this case pinned memory is not used and this saved memory.
             It will not be an error if this is False and you pass GPU array,
             just that it is inefficient.
+        **kwargs (optional): additional arguments. These include ``gpu_device_id``(GPU ID)
 
         Notes
         -----
@@ -182,6 +184,7 @@ class RawGpuNUFFT:
             sector_width,
             osf,
             balance_workload,
+            **kwargs
         )
 
     def toggle_grad_traj(self):


### PR DESCRIPTION
- Solves #289

This PR adds support for selecting the CUDA device using `gpu_device_id` in both `cufinufft` and `gpunufft` operators:
-  Adds optional `gpu_device_id` to kwargs
- Sets cupy cuda device in cufinufft constructor.
- Passes `gpu_device_id` to gpunufft's NUFFTOp (compatible with recent changes in gpuNUFFT https://github.com/chaithyagr/gpuNUFFT/pull/26)

Usage example: 
<pre>``` import mrinufft 
import numpy as np
nufft = mrinufft.get_operator(
    backend_name="cufinufft", wrt_data=True, wrt_traj=False
)(
    samples=np.random.rand(100,3),
    shape=(20,20,20),
    density="pipe",
    squeeze_dims=False,
    gpu_device_id=1
)``` </pre>
If the specified gpu_device_id is invalid, a warning will be issued like:
`Failed to set CUDA device 1: cudaErrorInvalidDevice: invalid device ordinal`
and the code will fall back to CUDA device 0. Otherwise, device 1 will be used.

