### PR TITLE
Efficient CG for Cufinufft

### DIFF
--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -828,22 +828,29 @@ class MRICufiNUFFT(FourierOperatorBase):
         float
             Lipschitz constant of the operator.
         """
-        tmp_op = self.__class__(
-            self.samples,
-            self.shape,
-            density=self.density,
-            n_coils=1,
-            smaps=None,
-            squeeze_dims=True,
-            **kwargs,
-        )
+        # Disable coil dimension for faster computation
+        n_coils = self.n_coils
+        smaps = self.smaps
+        squeeze_dims = self.squeeze_dims
+
+        self.smaps = None
+        self.n_coils = 1
+        self.squeeze_dims = True
+
         x = 1j * np.random.random(self.shape).astype(self.cpx_dtype, copy=False)
         x += np.random.random(self.shape).astype(self.cpx_dtype, copy=False)
 
         x = cp.asarray(x)
-        return power_method(
-            max_iter, tmp_op, norm_func=lambda x: cp.linalg.norm(x.flatten()), x=x
+        lipschitz_cst = power_method(
+            max_iter, self, norm_func=lambda x: cp.linalg.norm(x.flatten()), x=x
         )
+
+        # restore coil setup
+        self.n_coils = n_coils
+        self.smaps = smaps
+        self.squeeze_dims = squeeze_dims
+
+        return lipschitz_cst
 
     def toggle_grad_traj(self):
         """Toggle between the gradient trajectory and the plan for type 1 transform."""


### PR DESCRIPTION
<!---
This is a suggested pull request template for mri-nufft.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://github.com/mind-inria/mri-nufft/blob/master/CONTRIBUTING.md) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Don't create an extra operator for computing the lipschitz constant for cufinufft, instead just save the smaps state and restore it afterwards. 

<!-- Message of single commit: -->

feat(cufinufft): don't create an extra operator for computing lipschitz_cst.