### PR TITLE
allow external progress bar to be used

### DIFF
--- a/examples/GPU/example_pinv.py
+++ b/examples/GPU/example_pinv.py
@@ -12,7 +12,7 @@ methods, to reconstruct images from non-uniform k-space data.
 
 import os
 import time
-
+from tqdm.auto import tqdm
 import cupy as cp
 import numpy as np
 from brainweb_dl import get_mri
@@ -86,15 +86,18 @@ METRICS = {
     "psnr": "PSNR",
 }
 
+MAX_ITER = 1000
 
 images = dict()
 iterations_cb = dict()
+pg = tqdm(total=MAX_ITER, position=0, leave=True)
 for optim in OPTIM:
     image, iter_cb = nufft.pinv_solver(
         kspace_data=kspace_data_gpu,
-        max_iter=1000,
+        max_iter=MAX_ITER,
         callback=mixed_cb,
         optim=optim,
+        progressbar=pg,
     )
     images[optim] = image.get().squeeze()  # retrieve image from GPU.
     iterations_cb[optim] = process_cb_results(iter_cb)
@@ -171,6 +174,8 @@ plt.show()
 
 images = dict()
 iterations_cb = dict()
+
+pg = tqdm(total=MAX_ITER, position=0, leave=True)
 for optim in OPTIM:
     image, iter_cb = nufft.pinv_solver(
         kspace_data=kspace_data_gpu,
@@ -178,6 +183,7 @@ for optim in OPTIM:
         callback=mixed_cb,
         damp=0.1,
         optim=optim,
+        progressbar=pg,
     )
     images[optim] = image.get().squeeze()  # retrieve image from GPU.
     iterations_cb[optim] = process_cb_results(iter_cb)

--- a/src/mrinufft/_utils.py
+++ b/src/mrinufft/_utils.py
@@ -5,6 +5,7 @@ from inspect import cleandoc
 from collections import defaultdict
 from collections.abc import Callable
 from functools import wraps
+from tqdm.auto import tqdm
 
 import numpy as np
 from numpy.typing import DTypeLike, NDArray
@@ -164,3 +165,14 @@ class MethodRegister:
         getter.__doc__ = f"""Get the {self.register_name} function from its name."""
         getter.__name__ = f"get_{self.register_name}"
         return getter
+
+
+def _progressbar(progressbar: bool | tqdm, max_iter: int) -> tqdm:
+    """Set progressbar for iterations."""
+    if isinstance(progressbar, tqdm):
+        progressbar.reset(max_iter)
+    elif isinstance(progressbar, bool):
+        progressbar = tqdm(range(max_iter), disable=not progressbar)
+    else:
+        raise ValueError("progressbar must be bool or tqdm instance")
+    return progressbar

--- a/src/mrinufft/extras/optim.py
+++ b/src/mrinufft/extras/optim.py
@@ -4,13 +4,14 @@
 """
 
 from collections.abc import Callable
-import numpy as np
-from tqdm.auto import tqdm
-from numpy.typing import NDArray
 
-from mrinufft._array_compat import get_array_module, with_numpy_cupy, CUPY_AVAILABLE
+import numpy as np
+from numpy.typing import NDArray
+from tqdm.auto import tqdm
+
+from mrinufft._array_compat import CUPY_AVAILABLE, get_array_module, with_numpy_cupy
+from mrinufft._utils import MethodRegister, _progressbar
 from mrinufft.operators.base import FourierOperatorBase
-from mrinufft._utils import MethodRegister
 
 _optim_docs = dict(
     base_params=r"""
@@ -237,7 +238,7 @@ def lsqr(
     x0: NDArray | None = None,
     x_init: NDArray | None = None,
     callback: Callable | None = None,
-    progressbar: bool = True,
+    progressbar: bool | tqdm = True,
 ):
     r"""
     Solve a general regularized linear least-squares problem using the LSQR algorithm.
@@ -335,7 +336,8 @@ def lsqr(
     sn2 = 0.0
     istop = 0
     callback_returns = []
-    for _ in tqdm(range(max_iter), disable=not progressbar):
+    progressbar = _progressbar(progressbar, max_iter)
+    for _ in range(max_iter):
         u *= -_bc_left(alpha, u)
         u += operator.op(v).reshape(operator.ksp_full_shape)
         beta = norm_batched(u)
@@ -450,6 +452,7 @@ def lsqr(
 
         if istop:
             break
+        progressbar.update()
     if operator.squeeze_dims:
         x = operator._safe_squeeze(x)
     if callback_returns:
@@ -470,7 +473,7 @@ def lsmr(
     x0: NDArray | None = None,
     x_init: NDArray | None = None,
     callback: Callable | None = None,
-    progressbar: bool = True,
+    progressbar: bool | tqdm = True,
 ):
     r"""
     Solve a general regularized linear least-squares problem using the LSMR algorithm.
@@ -615,7 +618,8 @@ def lsmr(
     normr = beta
 
     callback_returns = []
-    for _ in tqdm(range(max_iter), disable=not progressbar):
+    progressbar = _progressbar(progressbar, max_iter)
+    for _ in range(max_iter):
 
         u *= -_bc_left(alpha, u)
         u += A(v)
@@ -738,6 +742,7 @@ def lsmr(
 
         if istop:
             break
+        progressbar.update()
 
     if operator.squeeze_dims:
         x = operator._safe_squeeze(x)
@@ -756,7 +761,7 @@ def cg(
     x_init: NDArray | None = None,
     max_iter: int = 10,
     tol: float = 1e-4,
-    progressbar: bool = True,
+    progressbar: bool | tqdm = True,
     callback: Callable | None = None,
 ):
     r"""
@@ -801,7 +806,8 @@ def cg(
     image = image - velocity
 
     callbacks_results = []
-    for _ in tqdm(range(max_iter), disable=not progressbar):
+    progressbar = _progressbar(progressbar, max_iter)
+    for _ in range(max_iter):
         grad_new = operator.data_consistency(image, kspace_data).reshape(
             operator.img_full_shape
         )
@@ -831,6 +837,7 @@ def cg(
                     x0=x0,
                 )
             )
+        progressbar.update()
     if operator.squeeze_dims:
         image = operator._safe_squeeze(image)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for mri-nufft.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://github.com/mind-inria/mri-nufft/blob/master/CONTRIBUTING.md) that
will be enforced during the review process.
-->
Externally defined progress bar can be passed to methods that requires them (typically pinv_solver), by reusing them over call, it reduces the std output, and makes it more manageable. 

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- makes possible to use externally defined progress bar from tqdm
-

<!-- Message of single commit: -->

feat: pass existing progressbars