### PR TITLE
Add Toeplitz Embedding for Gram Operator

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,6 +157,7 @@ html_theme_options = {
             "sg_launcher_links",
             "colab_link",
         ],
+        "explanations/**": ["page-toc"],
     },
     "header_links_before_dropdown": 4,
     "icon_links": [

--- a/docs/explanations/mrinufft_convention.rst
+++ b/docs/explanations/mrinufft_convention.rst
@@ -12,21 +12,21 @@ The NUFFT Operator
 
 MRI-NUFFT provides a common interface for computing NUFFT, regardless of the chosen computation backend. All the backends implement the following methods and attributes. More technical details are available in the API reference.
 
-All MRI-NUFFT operators inherit from :class:`FourierOperatorBase` . The minimum signature of an MRI nufft operator is:
+All MRI-NUFFT operators inherit from :class:`mrinufft.operators.base.FourierOperatorBase` . The minimum signature of an MRI nufft operator is:
 
 .. code-block:: python
 
     class MRIOperator(FourierOperatorBase):
 
-          backend = "my-nufft-backend"
+        backend = "my-nufft-backend"
 
-          def __init__(samples: np.ndarray,
+        def __init__(samples: np.ndarray,
             shape:tuple[int,...],
             density: str | callable | np.ndarray | dict = False,
             n_coils: int = 1,
             n_batchs: int = 1,
             smaps: str | callable | np.ndarray | dict = False,
-            ):
+        ):
 
             self.samples = proper_trajectory(samples)
             self.shape = shape
@@ -66,7 +66,10 @@ The base NUFFT operators can be extended to add extra functionality. With MRI-NU
 Adding a NUFFT Backend
 ----------------------
 
-Adding a NUFFT backend to MRI-NUFFT should be easy. We recommend to check how other backends have been inplemented. CPU-based nufft interface can use the `FourierOperatorCPU` to minimize the boiler-plate. You can take inspiration from the following pull-request on GitHub: https://github.com/mind-inria/mri-nufft/pull/345
+Adding a NUFFT backend to MRI-NUFFT should be easy. We recommend to check how other backends have been inplemented. CPU-based nufft interface can use the :py:class:`mrinufft.operators.base.FourierOperatorCPU` to minimize the boiler-plate.
+
+For reference, see `this pull-request <https://github.com/mind-inria/mri-nufft/pull/345>`_ implementing the ``ducc0`` backend.
+
 
 .. _kspace_traj:
 

--- a/docs/explanations/nufft.rst
+++ b/docs/explanations/nufft.rst
@@ -349,10 +349,25 @@ Computing the Toeplitz Kernel
 The Toeplitz Kernel can be written as:
 
 .. math::
-   
+
     K[n] = \sum_{m=1}^{M} w_m e^{2i\pi \boldsymbol{\nu}_m r_n} \quad\text{with } n \in [-N,N]
 
-Which is the Adjoint NUFFT (type-1) of the input weights :math:`\boldsymbol{w}` on a grid of size :math:`2N`. Computing this adjoint NUFFT directly would thus require a 4N NUFFT (note that is is per dimension, so a 3D NUFFT would require 4\ :sup:`3`\=64 more memory for estimating the kernel). Instead we can leverage the hermitian symmetry of the kernel: :math:`K[-n] = K[n]^*`. This is done by computing the kernel by flipping the trajectory to reach the different quadrant (or octant in 3D). See the detail of the implementation in :py:mod:`mrinufft.operators.toeplitz` module.
+This is the Adjoint NUFFT (type-1) of the input weights :math:`\boldsymbol{w}`, but evaluated on the extended lag grid :math:`n \in [-N, N]` of size :math:`2N`. Computing this adjoint directly would require an oversized NUFFT plan (twice the resolution *per dimension*, i.e. :math:`2^d` more memory: :math:`2^3=8\times` in 3D, on top of the NUFFT's own internal gridding oversampling). We avoid this entirely: the kernel is assembled from adjoint NUFFTs computed on the **native** :math:`N`-sized grid, so the memory footprint is that of a single adjoint.
+
+Two observations make this possible:
+
+**Fourier-shift modulation.** A single adjoint NUFFT on the :math:`N`-grid yields the kernel only on the *inner* lags :math:`n \in [-N/2, N/2)`. Modulating the weights by a linear phase before the adjoint shifts the window of computed lags: by the shift theorem,
+
+.. math::
+
+   \sum_{m=1}^{M} \big(w_m e^{i \boldsymbol{\omega}_m \cdot \boldsymbol{s}}\big)\, e^{i \boldsymbol{\omega}_m r_n}
+   = \sum_{m=1}^{M} w_m\, e^{i \boldsymbol{\omega}_m (r_n + \boldsymbol{s})} = K[n + \boldsymbol{s}]
+
+where :math:`\boldsymbol{\omega}_m = 2\pi\boldsymbol{\nu}_m` are the sampling locations in radians. Choosing the integer shift :math:`\boldsymbol{s} = \pm N/2` along each axis slides the window onto the *outer* lags, recovering the full :math:`2N` support at :math:`N`-resolution.
+
+**Hermitian symmetry.** For real-valued weights :math:`\boldsymbol{w}`, the operator :math:`\boldsymbol{A^HWA}` is Hermitian, so :math:`K[-n] = K[n]^*`. This halves the work: only the half-space :math:`n_0 \geq 0` of the first axis is computed by modulation (the remaining sign combinations of the other axes), and the opposite half is filled by conjugate symmetry.
+
+The kernel is therefore built from :math:`2^{d-1}` adjoint NUFFTs (2 in 2D, 4 in 3D), each on the native :math:`N`-grid, covering every combination of inner/outer lags. Because the shifts land the zero lag at index :math:`[0, \dots, 0]` by construction, no post-hoc re-centering is needed. This scheme is exact for **any** trajectory but requires even grid sizes. See the detail of the implementation in :py:mod:`mrinufft.operators.toeplitz` module.
 
 
 

--- a/examples/operators/example_gram_toep.py
+++ b/examples/operators/example_gram_toep.py
@@ -1,0 +1,147 @@
+"""
+=====================================
+Gram Operator with Toeplitz Embedding
+=====================================
+
+This example demonstrates how the auto-adjoint Gram operator of the NUFFT
+operator can be efficiently implemented using Toeplitz embedding.
+
+This approach leverages the convolutional structure of the Gram operator to
+reduce computational complexity, making it suitable for large-scale imaging
+problems.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from mrinufft.operators import (
+    get_operator,
+    compute_toeplitz_kernel,
+    apply_toeplitz_kernel,
+)
+from mrinufft.display import display_2D_trajectory
+from mrinufft.trajectories import initialize_2D_spiral
+from mrinufft.density import voronoi
+
+plt.rcParams["image.cmap"] = "gray"
+
+# %%
+# Data preparation
+# ================
+#
+# Image loading
+# -------------
+#
+# For realistic a 2D image we will use the BrainWeb dataset,
+# installable using ``pip install brainweb-dl``.
+
+from brainweb_dl import get_mri
+
+mri_data = get_mri(0, "T1").astype(np.complex64)
+# toeplitz embedding requires the image to be cropped to an even size.
+mri_data = np.flip(mri_data, axis=(0, 1, 2))[90, :-1, :-1]
+mri_data = np.ascontiguousarray(mri_data)
+# %%
+
+plt.imshow(abs(mri_data))
+plt.axis("off")
+plt.title("Groundtruth")
+plt.show()
+
+# %%
+# Trajectory generation
+# ---------------------
+
+
+samples = initialize_2D_spiral(Nc=24, Ns=5000, nb_revolutions=10)
+density = voronoi(samples)
+
+# %%
+
+display_2D_trajectory(samples)
+plt.show()
+
+
+# %%
+# Operator setup
+# ==============
+nufft = get_operator("finufft")(samples, mri_data.shape, density=density)
+
+# %%
+# Naive Gram operator
+# -------------------
+
+gram_naive = nufft.adj_op(nufft.op(mri_data))
+
+gram_optim = nufft.gram_op(mri_data)  # will compute the kernel internally once.
+# %%
+
+relative_squared_error = (np.abs(gram_naive - gram_optim) / np.abs(gram_naive)) ** 2
+plt.figure(figsize=(12, 4))
+plt.subplot(131)
+plt.imshow(np.abs(gram_naive), vmin=0, vmax=np.percentile(np.abs(gram_naive), 99))
+plt.title("Gram Naive")
+plt.axis("off")
+plt.subplot(132)
+plt.imshow(np.abs(gram_optim), vmin=0, vmax=np.percentile(np.abs(gram_optim), 99))
+plt.title("Gram Optimized")
+plt.axis("off")
+plt.subplot(133)
+plt.imshow(
+    relative_squared_error,
+    vmin=0,
+    vmax=np.percentile(relative_squared_error, 99),
+)
+plt.title("Relative Squared Error")
+plt.axis("off")
+plt.colorbar(fraction=0.046, pad=0.04)
+plt.show()
+
+
+# %%
+# Comparing the timings
+# ---------------------
+from time import perf_counter
+
+naive_times = []
+for _ in range(100):
+    tic = perf_counter()
+    gram_naive = nufft.adj_op(nufft.op(mri_data))
+    toc = perf_counter()
+    naive_times.append(toc - tic)
+
+setup_times = []
+apply_times = []
+
+for _ in range(10):
+    tic = perf_counter()
+    toeplitz_kernel = nufft.compute_toeplitz_kernel()
+    toc = perf_counter()
+    setup_times.append(toc - tic)
+
+padded_array = np.zeros_like(toeplitz_kernel)
+for _ in range(100):
+    tic = perf_counter()
+    gram_optim = apply_toeplitz_kernel(
+        mri_data, nufft._toeplitz_kernel, padded_array=padded_array
+    )
+    toc = perf_counter()
+    apply_times.append(toc - tic)
+
+print(
+    f"Naive Gram time: {np.mean(naive_times)*1e3:.2f} ms ± {np.std(naive_times)*1e3:.2f} ms"
+)
+print(
+    f"Toeplitz setup time: {np.mean(setup_times)*1e3:.2f} ms ± {np.std(setup_times)*1e3:.2f} ms"
+)
+print(
+    f"Toeplitz apply time: {np.mean(apply_times)*1e3:.2f} ms ± {np.std(apply_times)*1e3:.2f} ms"
+)
+
+
+# %%
+# Going Further
+# ----------------
+# The Toeplitz embedding technique only speeds up the application of the Gram operator for the NUFFT steps,
+# and the expected speedup depends on the problem size and the trajectory.
+# For more details on the implication for the different backends refer to the `Benchmark <https://github.com/mind-inria/mri-nufft-benchmark>`_

--- a/src/mrinufft/operators/__init__.py
+++ b/src/mrinufft/operators/__init__.py
@@ -30,6 +30,7 @@ from .off_resonance import MRIFourierCorrected
 from .stacked import MRIStackedNUFFT
 from .subspace import MRISubspace
 from .cartesian import MRICartesianOperator
+from .toeplitz import compute_toeplitz_kernel, apply_toeplitz_kernel
 
 __all__ = [
     "FourierOperatorBase",
@@ -40,6 +41,8 @@ __all__ = [
     "check_backend",
     "get_operator",
     "list_backends",
+    "compute_toeplitz_kernel",
+    "apply_toeplitz_kernel",
 ]
 #
 # load all the interfaces modules

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -335,11 +335,12 @@ class FourierOperatorBase(ABC):
         """Compute the Gram operator with sensitivity maps."""
         xp = get_array_module(data)
         B, C, XYZ = self.n_batchs, self.n_coils, self.shape
-        gram_img = xp.zeros((B, C, *XYZ), dtype=self.cpx_dtype)
+        data = data.reshape(B, *XYZ)
+        gram_img = xp.zeros((B, 1, *XYZ), dtype=self.cpx_dtype)
         for b in range(B):
             for c in range(C):
                 coil_smap = self.smaps[c].reshape(*XYZ)
-                img_coil = data[b, c] * coil_smap
+                img_coil = data[b] * coil_smap
                 gram_img_coil = self._gram_op_toeplitz_raw(img_coil)
                 gram_img[b] += coil_smap.conj() * gram_img_coil.reshape(*XYZ)
         return gram_img

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -302,8 +302,16 @@ class FourierOperatorBase(ABC):
         """
         pass
 
+    @abstractmethod
+    def _op(self, image: NDArray, coeffs: NDArray) -> NDArray:
+        """Low level operator implementation."""
+
+    @abstractmethod
+    def _adj_op(self, coeffs: NDArray, image: NDArray) -> NDArray:
+        """Low level adjoint operator implementation."""
+
     @with_numpy_cupy
-    def gram_op(self, data, toeplitz=True):
+    def gram_op(self, data: NDArray, toeplitz: bool = True) -> NDArray:
         """Compute the Gram operator of the NUFFT.
 
         Parameters
@@ -362,7 +370,7 @@ class FourierOperatorBase(ABC):
 
         if self._toeplitz_kernel is None:
             self.compute_toeplitz_kernel()
-        return apply_toeplitz_kernel(data, self._toeplitz_kernel)
+        return apply_toeplitz_kernel(data, self._toeplitz_kernel)  # type: ignore
 
     def data_consistency(self, image_data: NDArray, obs_data: NDArray) -> NDArray:
         """Compute the gradient data consistency.

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -196,6 +196,7 @@ class FourierOperatorBase(ABC):
             raise RuntimeError(f"'{self.backend}' backend is not available.")
         self._smaps = None
         self._density = None
+        self._toeplitz_kernel = None
         self._n_coils = 1
         self._n_batchs = 1
         self.squeeze_dims = False
@@ -301,6 +302,67 @@ class FourierOperatorBase(ABC):
         """
         pass
 
+    @with_numpy_cupy
+    def gram_op(self, data, toeplitz=True):
+        """Compute the Gram operator of the NUFFT.
+
+        Parameters
+        ----------
+        data: NDArray
+            Input data array.
+
+        toeplitz: bool, default True
+            If True, use the Toeplitz method to compute the Gram operator.
+            If False, compute it using the direct method.
+
+        Returns
+        -------
+        NDArray
+            Result of the Gram operator.
+        """
+        self.check_shape(image=data)
+        data = auto_cast(data, self.cpx_dtype)
+        if not toeplitz:
+            return self.adj_op(self.op(data))
+
+        if self.uses_sense:
+            ret = self._gram_op_sense(data)
+        else:
+            ret = self._gram_op_calibless(data)
+        return self._safe_squeeze(ret)
+
+    def _gram_op_sense(self, data):
+        """Compute the Gram operator with sensitivity maps."""
+        xp = get_array_module(data)
+        B, C, XYZ = self.n_batchs, self.n_coils, self.shape
+        gram_img = xp.zeros((B, C, *XYZ), dtype=self.cpx_dtype)
+        for b in range(B):
+            for c in range(C):
+                coil_smap = self.smaps[c].reshape(*XYZ)
+                img_coil = data[b, c] * coil_smap
+                gram_img_coil = self._gram_op_toeplitz_raw(img_coil)
+                gram_img[b] += coil_smap.conj() * gram_img_coil.reshape(*XYZ)
+        return gram_img
+
+    def _gram_op_calibless(self, data):
+        """Compute the Gram operator without sensitivity maps."""
+        ...
+        xp = get_array_module(data)
+        B, C, XYZ = self.n_batchs, self.n_coils, self.shape
+
+        dataf = data.reshape(B * C, *XYZ)
+        ret = xp.zeros_like(dataf)
+        for i in range(B * C):
+            ret[i] = self._gram_op_toeplitz_raw(dataf[i].reshape(*XYZ))
+        return ret.reshape(B, C, *XYZ)
+
+    def _gram_op_toeplitz_raw(self, data) -> NDArray:
+        from .toeplitz import apply_toeplitz_kernel
+
+        if self._toeplitz_kernel is None:
+            self.compute_toeplitz_kernel()
+        return apply_toeplitz_kernel(data, self._toeplitz_kernel)
+
     def data_consistency(self, image_data: NDArray, obs_data: NDArray) -> NDArray:
         """Compute the gradient data consistency.
 
@@ -323,6 +385,13 @@ class FourierOperatorBase(ABC):
         return MRIFourierCorrected(
             self, b0_map, readout_time, r2star_map, mask, interpolator
         )
+
+    def compute_toeplitz_kernel(self) -> NDArray:
+        """Compute the Toeplitz kernel and set it."""
+        from .toeplitz import compute_toeplitz_kernel
+
+        self._toeplitz_kernel = compute_toeplitz_kernel(self, self.density)
+        return self._toeplitz_kernel
 
     def compute_smaps(
         self,
@@ -1078,7 +1147,7 @@ def power_method(
     def AHA(x):
         if isinstance(operator, Callable):
             return operator(x)
-        return operator.adj_op(operator.op(x))
+        return operator.gram_op(x, toeplitz=False)
 
     if norm_func is None:
         norm_func = np.linalg.norm

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -669,14 +669,14 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         image_data = cp.asarray(data)
         image_dataf = cp.reshape(image_data, (B, *XYZ))
         img_d = cp.zeros((B, *XYZ), dtype=self.cpx_dtype)
-        data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
         smaps_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
 
         padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
         for i in range(B * C // T):
             idx_coils = np.arange(i * T, (i + 1) * T) % C
             idx_batch = np.arange(i * T, (i + 1) * T) // C
-            cp.copyto(data_batched, image_dataf[idx_batch])
+            # fancy indexing already returns a fresh array, safe to mutate in place
+            data_batched = image_dataf[idx_batch]
             if not self.smaps_cached:
                 smaps_batched.set(self.smaps[idx_coils].reshape((T, *XYZ)))
             else:
@@ -695,10 +695,9 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         XYZ = self.shape
         image_dataf = np.reshape(data, (B * C, *XYZ))
         if img_d is None:
-            img_d = np.zeros((B * C, *XYZ), dtype=self.cpx_dtype)
+            img_d = np.empty((B * C, *XYZ), dtype=self.cpx_dtype)
         else:
-            img_d.reshape((B * C, *XYZ))
-            img_d.fill(0)
+            img_d = img_d.reshape((B * C, *XYZ))
         data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
         padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
         for i in range(B * C // T):
@@ -713,19 +712,19 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         XYZ = self.shape
 
         image_data = cp.asarray(data).reshape(B * C, *XYZ)
-        data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
         padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
 
         if img_d is None:
-            img_d = cp.zeros((B * C, *XYZ), dtype=self.cpx_dtype)
+            img_d = cp.empty((B * C, *XYZ), dtype=self.cpx_dtype)
         else:
-            img_d.reshape((B * C, *XYZ))
-            img_d.fill(0)
+            img_d = img_d.reshape((B * C, *XYZ))
 
         for i in range(B * C // T):
-            cp.copyto(data_batched, image_data[i * T : (i + 1) * T])
-            self._gram_op_raw_device(data_batched, data_batched, padded_array)
-            img_d[i * T : (i + 1) * T] = data_batched
+            self._gram_op_raw_device(
+                image_data[i * T : (i + 1) * T],
+                img_d[i * T : (i + 1) * T],
+                padded_array,
+            )
         img_d = img_d.reshape((B, C, *XYZ))
         return img_d
 

--- a/src/mrinufft/operators/interfaces/cufinufft.py
+++ b/src/mrinufft/operators/interfaces/cufinufft.py
@@ -382,7 +382,7 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             else:
                 smaps_batched = self.smaps[idx_coils].reshape((T, *XYZ))
             data_batched *= smaps_batched
-            self.__op(data_batched, ksp_d[i * T : (i + 1) * T])
+            self._op(data_batched, ksp_d[i * T : (i + 1) * T])
 
         return ksp_d.reshape((B, C, K))
 
@@ -406,7 +406,7 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             else:
                 cp.copyto(coil_img_d, self.smaps[idx_coils])
             coil_img_d *= data_batched
-            self.__op(coil_img_d, ksp_batched)
+            self._op(coil_img_d, ksp_batched)
             ksp[i * T : (i + 1) * T] = ksp_batched.get()
         ksp = ksp.reshape((B, C, K))
         return ksp
@@ -418,7 +418,7 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         if ksp_d is None:
             ksp_d = cp.empty((B * C, K), dtype=self.cpx_dtype)
         for i in range((B * C) // T):
-            self.__op(
+            self._op(
                 data[i * T : (i + 1) * T],
                 ksp_d[i * T : (i + 1) * T],
             )
@@ -439,13 +439,13 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         data_ = data.reshape(B * C, *XYZ)
         for i in range((B * C) // T):
             coil_img_d.set(data_[i * T : (i + 1) * T])
-            self.__op(coil_img_d, ksp_d)
+            self._op(coil_img_d, ksp_d)
             ksp[i * T : (i + 1) * T] = ksp_d.get()
         ksp = ksp.reshape((B, C, K))
         return ksp
 
     @nvtx_mark()
-    def __op(self, image_d, coeffs_d):
+    def _op(self, image_d, coeffs_d):
         # ensure everything is pointers before going to raw level.
         return self.raw_op.type2(image_d, coeffs_d)
 
@@ -504,7 +504,7 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
                 ksp_new *= self.density
             else:
                 ksp_new = coeffs[i * T : (i + 1) * T]
-            self.__adj_op(ksp_new, coil_img_d)
+            self._adj_op(ksp_new, coil_img_d)
             for t, b in enumerate(idx_batch):
                 img_d[b, :] += coil_img_d[t] * smaps_batched[t].conj()
         img_d = img_d.reshape((B, 1, *XYZ))
@@ -543,7 +543,7 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             ksp_batched.set(coeffs_f[i * T * K : (i + 1) * T * K].reshape(T, K))
             if self.uses_density:
                 ksp_batched *= density_batched
-            self.__adj_op(ksp_batched, coil_img_d)
+            self._adj_op(ksp_batched, coil_img_d)
 
             for t, b in enumerate(idx_batch):
                 img_d[b, :] += coil_img_d[t] * smaps_batched[t].conj()
@@ -565,9 +565,9 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             if self.uses_density:
                 cp.copyto(ksp_batched, coeffs_f[i * T : (i + 1) * T])
                 ksp_batched *= density_batched
-                self.__adj_op(ksp_batched, img_d[i * T : (i + 1) * T])
+                self._adj_op(ksp_batched, img_d[i * T : (i + 1) * T])
             else:
-                self.__adj_op(
+                self._adj_op(
                     coeffs_f[i * T : (i + 1) * T],
                     img_d[i * T : (i + 1) * T],
                 )
@@ -590,14 +590,154 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             ksp_batched.set(coeffs_[i * T : (i + 1) * T])
             if self.uses_density:
                 ksp_batched *= density_batched
-            self.__adj_op(ksp_batched, img_batched)
+            self._adj_op(ksp_batched, img_batched)
             img[i * T : (i + 1) * T] = img_batched.get()
         img = img.reshape((B, C, *XYZ))
         return img
 
     @nvtx_mark()
-    def __adj_op(self, coeffs_d, image_d):
+    def _adj_op(self, coeffs_d, image_d):
         return self.raw_op.type1(coeffs_d, image_d)
+
+    @with_numpy_cupy
+    def gram_op(self, data, img_d=None, toeplitz=True):
+        """Compute the Gram operator of the NUFFT.
+
+        Parameters
+        ----------
+        data: array
+            Input data array.
+        img_d: array, optional
+            Preallocated output array.
+        toeplitz: bool, default True
+            If True, use the Toeplitz method to compute the Gram operator.
+            If False, use the direct method.
+
+        Returns
+        -------
+        NDArray
+            Array with the Gram operator applied.
+        """
+        self.check_shape(image=data)
+        if not toeplitz:
+            return self.adj_op(self.op(data))
+        if self._toeplitz_kernel is None:
+            self.compute_toeplitz_kernel()
+        if self.uses_sense and is_cuda_array(data):
+            gram_func = self._gram_op_sense_device
+        elif self.uses_sense:
+            gram_func = self._gram_op_sense_host
+        elif is_cuda_array(data):
+            gram_func = self._gram_op_calibless_device
+        else:
+            gram_func = self._gram_op_calibless_host
+        ret = gram_func(data, img_d)
+        return self._safe_squeeze(ret)
+
+    def _gram_op_sense_host(self, data, img_d):
+        T, B, C = self.n_trans, self.n_batchs, self.n_coils
+        XYZ = self.shape
+        image_dataf = np.reshape(data, (B, *XYZ))
+
+        data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
+        smaps_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
+        padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
+
+        img_d = cp.zeros((B, *XYZ), dtype=self.cpx_dtype)
+        for i in range(B * C // T):
+            idx_coils = np.arange(i * T, (i + 1) * T) % C
+            idx_batch = np.arange(i * T, (i + 1) * T) // C
+            data_batched.set(image_dataf[idx_batch].reshape((T, *XYZ)))
+
+            if not self.smaps_cached:
+                smaps_batched.set(self.smaps[idx_coils].reshape((T, *XYZ)))
+            else:
+                smaps_batched = self.smaps[idx_coils].reshape((T, *XYZ))
+            data_batched *= smaps_batched
+
+            self._gram_op_raw_device(data_batched, data_batched, padded_array)
+            for t, b in enumerate(idx_batch):
+                img_d[b, :] += data_batched[t] * smaps_batched[t].conj()
+        img = img_d.get()
+        img = img_d.reshape((B, 1, *XYZ))
+        return img
+
+    def _gram_op_sense_device(self, data, img_d):
+        T, B, C = self.n_trans, self.n_batchs, self.n_coils
+        XYZ = self.shape
+
+        image_data = cp.asarray(data)
+        image_dataf = cp.reshape(image_data, (B, *XYZ))
+        img_d = cp.zeros((B, *XYZ), dtype=self.cpx_dtype)
+        data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
+        smaps_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
+
+        padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
+        for i in range(B * C // T):
+            idx_coils = np.arange(i * T, (i + 1) * T) % C
+            idx_batch = np.arange(i * T, (i + 1) * T) // C
+            cp.copyto(data_batched, image_dataf[idx_batch])
+            if not self.smaps_cached:
+                smaps_batched.set(self.smaps[idx_coils].reshape((T, *XYZ)))
+            else:
+                smaps_batched = self.smaps[idx_coils].reshape((T, *XYZ))
+            data_batched *= smaps_batched
+            self._gram_op_raw_device(data_batched, data_batched, padded_array)
+
+            for t, b in enumerate(idx_batch):
+                # TODO write a kernel for that.
+                img_d[b] += data_batched[t] * smaps_batched[t].conj()
+        img_d = img_d.reshape((B, 1, *XYZ))
+        return img_d
+
+    def _gram_op_calibless_host(self, data, img_d):
+        T, B, C = self.n_trans, self.n_batchs, self.n_coils
+        XYZ = self.shape
+        image_dataf = np.reshape(data, (B * C, *XYZ))
+        if img_d is None:
+            img_d = np.zeros((B * C, *XYZ), dtype=self.cpx_dtype)
+        else:
+            img_d.reshape((B * C, *XYZ))
+            img_d.fill(0)
+        data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
+        padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
+        for i in range(B * C // T):
+            data_batched.set(image_dataf[i * T : (i + 1) * T])
+            self._gram_op_raw_device(data_batched, data_batched, padded_array)
+            img_d[i * T : (i + 1) * T] = data_batched.get()
+        img_d = img_d.reshape((B, C, *XYZ))
+        return img_d
+
+    def _gram_op_calibless_device(self, data, img_d):
+        T, B, C = self.n_trans, self.n_batchs, self.n_coils
+        XYZ = self.shape
+
+        image_data = cp.asarray(data).reshape(B * C, *XYZ)
+        data_batched = cp.empty((T, *XYZ), dtype=self.cpx_dtype)
+        padded_array = cp.empty((T, *(s * 2 for s in XYZ)), dtype=self.cpx_dtype)
+
+        if img_d is None:
+            img_d = cp.zeros((B * C, *XYZ), dtype=self.cpx_dtype)
+        else:
+            img_d.reshape((B * C, *XYZ))
+            img_d.fill(0)
+
+        for i in range(B * C // T):
+            cp.copyto(data_batched, image_data[i * T : (i + 1) * T])
+            self._gram_op_raw_device(data_batched, data_batched, padded_array)
+            img_d[i * T : (i + 1) * T] = data_batched
+        img_d = img_d.reshape((B, C, *XYZ))
+        return img_d
+
+    def _gram_op_raw_device(self, in_d, out_d, padded_array=None):
+        """Apply the toeplitz Gram operator on device on a single image."""
+        # TODO Add support for batching with n_trans.
+        from mrinufft.operators.toeplitz import apply_toeplitz_kernel
+
+        cp.copyto(
+            out_d, apply_toeplitz_kernel(in_d, self._toeplitz_kernel, padded_array)
+        )
+        return out_d
 
     def data_consistency(self, image_data, obs_data):
         """Compute the data consistency estimation directly on gpu.
@@ -671,14 +811,14 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             else:
                 smaps_batched = self.smaps[idx_coils].reshape((T, *XYZ))
             data_batched *= smaps_batched
-            self.__op(data_batched, ksp_batched)
+            self._op(data_batched, ksp_batched)
 
             ksp_batched /= self.norm_factor
             ksp_batched -= obs_batched
 
             if self.uses_density:
                 ksp_batched *= self.density
-            self.__adj_op(ksp_batched, data_batched)
+            self._adj_op(ksp_batched, data_batched)
 
             for t, b in enumerate(idx_batch):
                 grad_d[b, :] += data_batched[t] * smaps_batched[t].conj()
@@ -710,13 +850,13 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             else:
                 smaps_batched = self.smaps[idx_coils].reshape((T, *XYZ))
             data_batched *= smaps_batched
-            self.__op(data_batched, ksp_batched)
+            self._op(data_batched, ksp_batched)
             ksp_batched /= self.norm_factor
             ksp_batched -= obs_dataf[i * T : (i + 1) * T]
 
             if self.uses_density:
                 ksp_batched *= self.density
-            self.__adj_op(ksp_batched, data_batched)
+            self._adj_op(ksp_batched, data_batched)
 
             for t, b in enumerate(idx_batch):
                 # TODO write a kernel for that.
@@ -743,12 +883,12 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         for i in range(B * C // T):
             data_batched.set(image_dataf[i * T : (i + 1) * T])
             obs_batched.set(obs_dataf[i * T : (i + 1) * T])
-            self.__op(data_batched, ksp_batched)
+            self._op(data_batched, ksp_batched)
             ksp_batched /= self.norm_factor
             ksp_batched -= obs_batched
             if self.uses_density:
                 ksp_batched *= self.density
-            self.__adj_op(ksp_batched, data_batched)
+            self._adj_op(ksp_batched, data_batched)
             data_batched /= self.norm_factor
             grad[i * T : (i + 1) * T] = data_batched.get()
         grad = grad.reshape((B, C, *XYZ))
@@ -769,12 +909,12 @@ class MRICufiNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
 
         for i in range(B * C // T):
             cp.copyto(data_batched, image_data[i * T : (i + 1) * T])
-            self.__op(data_batched, ksp_batched)
+            self._op(data_batched, ksp_batched)
             ksp_batched /= self.norm_factor
             ksp_batched -= obs_data[i * T : (i + 1) * T]
             if self.uses_density:
                 ksp_batched *= self.density
-            self.__adj_op(ksp_batched, data_batched)
+            self._adj_op(ksp_batched, data_batched)
             grad[i * T : (i + 1) * T] = data_batched
         grad = grad.reshape((B, C, *XYZ))
         grad /= self.norm_factor

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -642,16 +642,6 @@ class MRIGpuNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
         # so we don't need to normalize it again.
         return 1
 
-    def compute_toeplitz_kernel(self) -> NDArray:
-        """Compute the Toeplitz kernel and set it."""
-        from mrinufft.operators.toeplitz import compute_toeplitz_kernel
-
-        # extra scaling for kernel is required.
-        self._toeplitz_kernel = compute_toeplitz_kernel(self, self.density) * int(
-            np.prod(self.shape) * 2**self.ndim
-        )
-        return self._toeplitz_kernel
-
     @classmethod
     def pipe(
         cls,

--- a/src/mrinufft/operators/interfaces/gpunufft.py
+++ b/src/mrinufft/operators/interfaces/gpunufft.py
@@ -527,6 +527,38 @@ class MRIGpuNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             data = get_array_module(coeffs).stack(result)
         return self._safe_squeeze(data)
 
+    def _get_single_raw_op(self):
+        """Return a coil-agnostic single-image/single-kspace raw operator.
+
+        Unlike ``raw_op`` (which bakes in ``n_coils`` and SENSE combination in
+        the underlying gpuNUFFT C++ operator), this is used for elementary
+        transforms that must be independent of coils/batches/smaps, such as
+        the Toeplitz kernel computation.
+        """
+        if getattr(self, "_raw_op_single", None) is None:
+            self._raw_op_single = RawGpuNUFFT(
+                samples=self.samples,
+                shape=self.shape,
+                n_coils=1,
+                density_comp=self.density,
+            )
+        return self._raw_op_single
+
+    def _adj_op(self, coeffs, image):
+        """Compute adjoint Non Uniform Fourier Transform in place."""
+        result = self._get_single_raw_op().adj_op(coeffs)
+        # results is F-ordered, we need to reshape it to C-order for the user
+
+        image[...] = result.reshape(image.shape)
+        return image
+
+    def _op(self, image, coeffs):
+        """Compute Non Uniform Fourier Transform in place."""
+        result = self._get_single_raw_op().op(image)
+        # results is F-ordered, we need to reshape it to C-order for the user
+        coeffs[...] = result.reshape(coeffs.shape)
+        return coeffs
+
     @property
     def uses_sense(self):
         """Return True if the Fourier Operator uses the SENSE method."""
@@ -581,6 +613,11 @@ class MRIGpuNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
             self._samples,
             density=self.density,
         )
+        if getattr(self, "_raw_op_single", None) is not None:
+            self._raw_op_single.set_pts(
+                self._samples,
+                density=self.density,
+            )
 
     @FourierOperatorBase.density.setter
     def density(self, new_density):
@@ -597,6 +634,23 @@ class MRIGpuNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
                 self._samples,
                 density=new_density,
             )
+
+    @property
+    def norm_factor(self):
+        """Return the normalization factor for the operator."""
+        # gpuNUFFT is already normalized at the C++ level,
+        # so we don't need to normalize it again.
+        return 1
+
+    def compute_toeplitz_kernel(self) -> NDArray:
+        """Compute the Toeplitz kernel and set it."""
+        from mrinufft.operators.toeplitz import compute_toeplitz_kernel
+
+        # extra scaling for kernel is required.
+        self._toeplitz_kernel = compute_toeplitz_kernel(self, self.density) * int(
+            np.prod(self.shape) * 2**self.ndim
+        )
+        return self._toeplitz_kernel
 
     @classmethod
     def pipe(
@@ -740,3 +794,150 @@ class MRIGpuNUFFT(FourierOperatorBase, _ToggleGradPlanMixin):
     # data_consistency N / adj_op coil n
     #
     # This should bring some performance improvements, due to the asynchronous stuff.
+
+    @with_numpy_cupy
+    def gram_op(self, data, img_d=None, toeplitz=True):
+        """Compute the Gram operator of the NUFFT.
+
+        Parameters
+        ----------
+        data: array
+            Input data array.
+        img_d: array, optional
+            Preallocated output array.
+        toeplitz: bool, default True
+            If True, use the Toeplitz method to compute the Gram operator.
+            If False, use the direct method.
+
+        Returns
+        -------
+        NDArray
+            Array with the Gram operator applied.
+        """
+        self.check_shape(image=data)
+        if not toeplitz:
+            return self.adj_op(self.op(data))
+        if self._toeplitz_kernel is None:
+            self.compute_toeplitz_kernel()
+        if self.uses_sense and is_cuda_array(data):
+            gram_func = self._gram_op_sense_device
+        elif self.uses_sense:
+            gram_func = self._gram_op_sense_host
+        elif is_cuda_array(data):
+            gram_func = self._gram_op_calibless_device
+        else:
+            gram_func = self._gram_op_calibless_host
+        ret = gram_func(data, img_d)
+        return self._safe_squeeze(ret)
+
+    def _get_coil_smap_gpu(self, coil_idx, smap_buffer, stream):
+        """Fetch a single coil's sensitivity map onto the GPU.
+
+        The smaps are only available pinned on host (`self.raw_op.pinned_smaps`),
+        so we copy a single coil at a time asynchronously using a cupy stream,
+        instead of transferring the whole smaps array to the GPU.
+
+        """
+        # FIXME: Use true asynchronous copy for gram
+        # ``smap_buffer`` is reused across coils, so the default stream (which
+        # reads the previous coil's data out of it) must finish before this
+        # overwrite is queued on ``stream`` -- otherwise the two streams race
+        # and the multiply/accumulate below can read a partially-overwritten
+        # or wrong-coil buffer.
+        cp.cuda.get_current_stream().synchronize()
+        smap_buffer.set(self.raw_op.pinned_smaps[:, coil_idx], stream=stream)
+        return smap_buffer.reshape(self.shape, order="F")
+
+    def _gram_op_sense_host(self, data, img_d):
+        B, C, XYZ = self.n_batchs, self.n_coils, self.shape
+        image_dataf = np.reshape(data, (B, *XYZ))
+
+        if img_d is None:
+            img_d = np.zeros((B, *XYZ), dtype=self.cpx_dtype)
+        else:
+            img_d = img_d.reshape((B, *XYZ))
+            img_d.fill(0)
+
+        data_gpu = cp.empty(XYZ, dtype=self.cpx_dtype)
+        smap_buffer = cp.empty(int(np.prod(XYZ)), dtype=self.cpx_dtype)
+        padded_array = cp.empty(tuple(s * 2 for s in XYZ), dtype=self.cpx_dtype)
+        stream = cp.cuda.Stream(non_blocking=True)
+
+        for b in range(B):
+            data_gpu.set(image_dataf[b])
+            for c in range(C):
+                smap_gpu = self._get_coil_smap_gpu(c, smap_buffer, stream)
+                stream.synchronize()
+                coil_img = data_gpu * smap_gpu
+                self._gram_op_raw_device(coil_img, coil_img, padded_array)
+                img_d[b] += (coil_img * smap_gpu.conj()).get()
+        return img_d.reshape((B, 1, *XYZ))
+
+    def _gram_op_sense_device(self, data, img_d):
+        B, C, XYZ = self.n_batchs, self.n_coils, self.shape
+        image_dataf = cp.asarray(data).reshape((B, *XYZ))
+
+        img_d = cp.zeros((B, *XYZ), dtype=self.cpx_dtype)
+        smap_buffer = cp.empty(int(np.prod(XYZ)), dtype=self.cpx_dtype)
+        padded_array = cp.empty(tuple(s * 2 for s in XYZ), dtype=self.cpx_dtype)
+        stream = cp.cuda.Stream(non_blocking=True)
+
+        for b in range(B):
+            for c in range(C):
+                smap_gpu = self._get_coil_smap_gpu(c, smap_buffer, stream)
+                stream.synchronize()
+                coil_img = image_dataf[b] * smap_gpu
+                self._gram_op_raw_device(coil_img, coil_img, padded_array)
+                img_d[b] += coil_img * smap_gpu.conj()
+        return img_d.reshape((B, 1, *XYZ))
+
+    def _gram_op_calibless_host(self, data, img_d):
+        B, C, XYZ = self.n_batchs, self.n_coils, self.shape
+        image_dataf = np.reshape(data, (B, C, *XYZ))
+
+        if img_d is None:
+            img_d = np.zeros((B, C, *XYZ), dtype=self.cpx_dtype)
+        else:
+            img_d = img_d.reshape((B, C, *XYZ))
+            img_d.fill(0)
+
+        data_gpu = cp.empty(XYZ, dtype=self.cpx_dtype)
+        padded_array = cp.empty(tuple(s * 2 for s in XYZ), dtype=self.cpx_dtype)
+        for b in range(B):
+            for c in range(C):
+                data_gpu.set(image_dataf[b, c])
+                self._gram_op_raw_device(data_gpu, data_gpu, padded_array)
+                img_d[b, c] = data_gpu.get()
+        return img_d
+
+    def _gram_op_calibless_device(self, data, img_d):
+        B, C, XYZ = self.n_batchs, self.n_coils, self.shape
+        image_data = cp.asarray(data).reshape((B, C, *XYZ))
+
+        if img_d is None:
+            img_d = cp.zeros((B, C, *XYZ), dtype=self.cpx_dtype)
+        else:
+            img_d = img_d.reshape((B, C, *XYZ))
+            img_d.fill(0)
+
+        padded_array = cp.empty(tuple(s * 2 for s in XYZ), dtype=self.cpx_dtype)
+        for b in range(B):
+            for c in range(C):
+                self._gram_op_raw_device(image_data[b, c], img_d[b, c], padded_array)
+        return img_d
+
+    def _gram_op_raw_device(self, in_d, out_d, padded_array=None):
+        """Apply the toeplitz Gram operator on device on a single image."""
+        from mrinufft.operators.toeplitz import apply_toeplitz_kernel
+
+        # The toeplitz kernel is always computed on host for gpuNUFFT (samples
+        # and adj_op live on host memory), so keep a GPU copy around for reuse.
+        if getattr(self, "_toeplitz_kernel_gpu_src", None) is not self._toeplitz_kernel:
+            self._toeplitz_kernel_gpu = cp.asarray(self._toeplitz_kernel)
+            self._toeplitz_kernel_gpu_src = self._toeplitz_kernel
+
+        cp.copyto(
+            out_d,
+            apply_toeplitz_kernel(in_d, self._toeplitz_kernel_gpu, padded_array),
+        )
+        return out_d

--- a/src/mrinufft/operators/interfaces/torchkbnufft.py
+++ b/src/mrinufft/operators/interfaces/torchkbnufft.py
@@ -165,6 +165,16 @@ class MRITorchKbNufft(FourierOperatorBase):
         return self._safe_squeeze(kdata)
 
     @with_torch
+    def _op(self, data, out):
+        self._tkb_op.forward(data, omega=self.samples.t())
+        return out
+
+    @with_torch
+    def _adj_op(self, coeffs, out):
+        self._tkb_adj_op.forward(data=coeffs, omega=self.samples.t())
+        return out
+
+    @with_torch
     def adj_op(self, coeffs, out=None):
         """Backward Operation.
 
@@ -212,6 +222,35 @@ class MRITorchKbNufft(FourierOperatorBase):
         obs_data = obs_data.to(self.device, copy=False)
         ret = self.adj_op(self.op(data) - obs_data)
         return ret
+
+    @with_torch
+    def gram_op(self, data, toeplitz=True):
+        """Compute the Gram operator."""
+        import torchkbnufft as tkbn
+
+        if not toeplitz:
+            return self.adj_op(self.op(data))
+        if not hasattr(self, "_gram_op"):
+            # initialize the toeplitz approximation for the gram operator.
+            self._gram_op = tkbn.ToepNufft()
+            self._gram_op_kernel = tkbn.calc_toeplitz_kernel(
+                self.samples.t(), self.shape
+            )
+
+        data = data.to(dtype=self._gram_op_kernel.dtype, copy=False)
+        smaps = self.smaps
+        if smaps is not None:
+            smaps = smaps.to(data.dtype, copy=False)
+            # ToepNufft expects one smaps set per batch element.
+            smaps = smaps.unsqueeze(0).expand(data.shape[0], *smaps.shape)
+
+        img = self._gram_op(
+            data,
+            self._gram_op_kernel,
+            smaps=smaps,
+            norm="ortho",
+        ).reshape(data.shape)
+        return self._safe_squeeze(img)
 
     @classmethod
     @with_torch

--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -313,6 +313,12 @@ class MRIFourierCorrected(FourierOperatorBase):
             img = img.get()
         return self._safe_squeeze(img)
 
+    def _op(self, image, coeffs):
+        return self._fourier_op._op(image, coeffs)
+
+    def _adj_op(self, coeffs, image):
+        return self._fourier_op._adj_op(coeffs, image)
+
     def get_lipschitz_cst(self, max_iter=10, **kwargs):
         """Return the Lipschitz constant of the operator.
 

--- a/src/mrinufft/operators/stacked.py
+++ b/src/mrinufft/operators/stacked.py
@@ -239,6 +239,17 @@ class MRIStackedNUFFT(FourierOperatorBase):
         return ksp
 
     @with_numpy_cupy
+    def _op(self, data, ksp=None):
+        """Forward operator."""
+        NS, NZ = len(self._samples2d), len(self.z_index)
+        tmp = self._fftz(data)
+        xp = get_array_module(data)
+        ksp = xp.zeros(NZ, NS, dtype=self.cpx_dtype)
+        for i in range(NZ):
+            self.operator._op(tmp[..., self.z_index[i], :], ksp[i])
+        return ksp
+
+    @with_numpy_cupy
     def adj_op(self, coeffs, img=None):
         """Adjoint operator."""
         if self.uses_sense:
@@ -282,6 +293,15 @@ class MRIStackedNUFFT(FourierOperatorBase):
             imgz[b][..., self.z_index] = xp.ascontiguousarray(adj)
         imgz = xp.reshape(imgz, (B, C, *XYZ))
         img = self._ifftz(imgz)
+        return img
+
+    @with_numpy_cupy
+    def _adj_op(self, coeffs, img):
+        """Adjoint operator."""
+        tmp = np.zeros(self.shape, dtype=self.cpx_dtype)
+        for i in range(len(self.z_index)):
+            self.operator._adj_op(coeffs[i], tmp[..., self.z_index[i]])
+        img = self._ifftz(tmp)
         return img
 
     def get_lipschitz_cst(self, max_iter=10):

--- a/src/mrinufft/operators/subspace.py
+++ b/src/mrinufft/operators/subspace.py
@@ -1,5 +1,6 @@
 """Subspace NUFFT Operator wrapper."""
 
+from numpy.typing import NDArray
 from mrinufft._array_compat import (
     _get_device,
     _to_interface,
@@ -46,7 +47,14 @@ class MRISubspace(FourierOperatorBase):
 
     """
 
-    def __init__(self, fourier_op, subspace_basis, use_gpu=False):
+    available = True
+
+    def __init__(
+        self,
+        fourier_op: FourierOperatorBase,
+        subspace_basis: NDArray,
+        use_gpu: bool = False,
+    ):
         self._fourier_op = fourier_op
 
         self.subspace_basis = subspace_basis
@@ -92,7 +100,6 @@ class MRISubspace(FourierOperatorBase):
             # actual transform
             _y = self._fourier_op.op(data_d[idx], *args)
             _y = _y.reshape(*_y.shape[:-1], self.n_frames, -1)
-
             # back-project on time domain
             y += basis_element.conj() * _y.swapaxes(-2, -1)
 
@@ -158,6 +165,12 @@ class MRISubspace(FourierOperatorBase):
             y = y.swapaxes(0, 1)
 
         return y
+
+    def _op(self, image, coeffs):
+        return self._fourier_op._op(image, coeffs)
+
+    def _adj_op(self, coeffs, image):
+        return self._fourier_op._adj_op(coeffs, image)
 
     def __getattr__(self, name):
         """Delegate attribute access to the underlying fourier operator."""

--- a/src/mrinufft/operators/toeplitz.py
+++ b/src/mrinufft/operators/toeplitz.py
@@ -1,0 +1,201 @@
+"""Toeplitz approximation of the Auto-adjoint operator for NUFFT."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from mrinufft._array_compat import with_numpy_cupy, get_array_module
+from .base import FourierOperatorBase
+
+
+def calc_toeplitz_kernel(
+    nufft: FourierOperatorBase, weights: NDArray | None = None
+) -> NDArray:
+    """
+    Calculate the Toeplitz kernel for the NUFFT operator.
+
+    Parameters
+    ----------
+    nufft : FourierOperatorBase
+        The NUFFT operator instance.
+    weights : NDArray | None, optional
+        Weights to apply during the adjoint operation. If None, uses the
+        density compensation from the NUFFT operator if available, otherwise
+        uses uniform weights. Default is None.
+
+    Returns
+    -------
+    NDArray
+        The computed Toeplitz kernel in the frequency domain.
+
+    See Also
+    --------
+    apply_toeplitz: Apply the Toeplitz kernel to an image.
+    """
+    backup_density = None
+    if nufft.uses_density:
+        backup_density = nufft.density.copy()
+        nufft.density = None
+        backup_density_method = nufft._density_method
+        nufft._density_method = None
+    if weights is None and backup_density is not None:
+        weights = backup_density
+    elif weights is None:
+        xp = get_array_module(nufft.samples)
+        weights = xp.ones(nufft.n_samples, dtype=nufft.dtype)
+
+    if nufft.ndim == 2:
+        kernel = _calc_toeplitz_kernel_2d(nufft, weights)
+    elif nufft.ndim == 3:
+        kernel = _calc_toeplitz_kernel_3d(nufft, weights)
+    else:
+        raise ValueError(
+            f"Toeplitz kernel calculation not implemented for ndim={nufft.ndim}"
+        )
+
+    # set back density
+    if backup_density is not None:
+        nufft.density = backup_density
+        nufft._density_method = backup_density_method
+
+    return kernel
+
+
+def _calc_toeplitz_kernel_2d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
+    xp = get_array_module(nufft.samples)
+
+    # Trajectory Flipping (Y-axis)
+    samples_orig = nufft.samples.copy()
+    samples_flip_y = samples_orig.copy()
+    samples_flip_y[:, 1] *= -1
+
+    k1 = nufft.adj_op(weights)
+    nufft.update_samples(samples_flip_y, unsafe=True)
+    k2 = nufft.adj_op(weights)
+
+    # Restore original samples for nufft object consistency
+    nufft.update_samples(samples_orig, unsafe=True)
+
+    # Assemble Spatial Kernel
+    zero_y = xp.zeros((k1.shape[0], 1), dtype=k1.dtype)
+    ky = xp.concatenate([k1, zero_y, k2[:, :0:-1]], axis=1)
+
+    zero_x = xp.zeros((1, ky.shape[1]), dtype=ky.dtype)
+    kernel = xp.concatenate([ky, zero_x, ky[:0:-1, :].conj()], axis=0)
+
+    # Enforce strict Hermitian symmetry
+    kernel = (kernel + kernel[::-1, ::-1].conj()) / 2
+
+    # Move the PSF peak from center to [0, 0] to align with corner-padded image
+    # This is more robust than trying to mess with fftshifts and off-by-one errors
+    #
+    peak_idx = xp.unravel_index(xp.argmax(xp.abs(kernel)), kernel.shape)
+    kernel = xp.roll(kernel, shift=[-p for p in peak_idx], axis=(0, 1))
+
+    # osf is fixed to 2.0
+    # TODO: Generalize to other osf values by cropping / padding ?
+    # what is the relation with the NUFFT osf grid size ?
+    grid_size = xp.prod(xp.array(nufft.shape) * 2)
+    scale = xp.prod(xp.array(kernel.shape)) / grid_size
+    return xp.fft.fftn(kernel * scale)
+
+
+def _calc_toeplitz_kernel_3d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
+    xp = get_array_module(nufft.samples)
+
+    # Initialize the operator (density=False to get the raw Gram kernel)
+
+    # 1. Prepare Trajectories for 4 octants
+    # We flip Y, Z, and YZ. X is handled by Hermitian symmetry later.
+    samples_orig = nufft.samples.copy()
+
+    samples_z = samples_orig.copy()
+    samples_z[:, 2] *= -1
+
+    samples_y = samples_orig.copy()
+    samples_y[:, 1] *= -1
+
+    samples_yz = samples_orig.copy()
+    samples_yz[:, 1] *= -1
+    samples_yz[:, 2] *= -1
+
+    # 2. Compute 4 Adjoints
+    k00 = nufft.adj_op(weights)  # Original
+
+    nufft.update_samples(samples_z, unsafe=True)
+    k01 = nufft.adj_op(weights)  # Z-flipped
+
+    nufft.update_samples(samples_y, unsafe=True)
+    k10 = nufft.adj_op(weights)  # Y-flipped
+
+    nufft.update_samples(samples_yz, unsafe=True)
+    k11 = nufft.adj_op(weights)  # YZ-flipped
+
+    nufft.update_samples(samples_orig, unsafe=True)
+
+    # 3. Assemble Z-axis (axis 2)
+    zero_z = xp.zeros((*k00.shape[:2], 1), dtype=k00.dtype)
+    kz0 = xp.concatenate([k00, zero_z, k01[:, :, :0:-1]], axis=2)
+    kz1 = xp.concatenate([k10, zero_z, k11[:, :, :0:-1]], axis=2)
+
+    # 4. Assemble Y-axis (axis 1)
+    # flip and conjugate the second half of the Y-assembly relative to Z
+    # but since these are all forward lags, the kyz assembly follows the 2D logic
+    zero_y = xp.zeros((kz0.shape[0], 1, kz0.shape[2]), dtype=kz0.dtype)
+    kyz = xp.concatenate([kz0, zero_y, kz1[:, :0:-1, :]], axis=1)
+
+    # 5. Assemble X-axis using Hermitian symmetry (axis 0)
+    zero_x = xp.zeros((1, *kyz.shape[1:]), dtype=kyz.dtype)
+    # Reflect and conjugate across all dimensions to fill the negative X lags
+    kernel = xp.concatenate([kyz, zero_x, kyz[:0:-1, :, :].conj()], axis=0)
+
+    # 6. Hermitify to ensure strict symmetry
+    kernel = (kernel + kernel[::-1, ::-1, ::-1].conj()) / 2
+
+    # Move the PSF peak from center to [0, 0] to align with corner-padded image
+    # This is more robust than trying to mess with fftshifts and off-by-one errors
+    pos = xp.argmax(xp.abs(kernel))
+    if xp.__name__ == "cupy":
+        pos = pos.get()
+    peak_idx = xp.unravel_index(pos, kernel.shape)
+    kernel = xp.roll(kernel, shift=[-p for p in peak_idx], axis=(0, 1, 2))
+
+    return xp.fft.fftn(kernel)
+
+
+def apply_toeplitz(
+    image: NDArray,
+    toeplitz_kernel: NDArray,
+) -> NDArray:
+    """Apply the 2D or 3D Toeplitz kernel to an image using FFT.
+
+    Parameters
+    ----------
+    image : NDArray
+        The input 2D or 3D image to which the Toeplitz kernel will be applied.
+    toeplitz_kernel : NDArray
+        The 3D Toeplitz kernel in the frequency domain.
+
+    Returns
+    -------
+    NDArray
+        The result of applying the Toeplitz kernel to the image.
+
+    See Also
+    --------
+    calc_toeplitz_kernel : Calculate the Toeplitz kernel to be used with this function.
+    """
+    xp = get_array_module(image)
+    # Use pre-allocation for speed (Corner Padding)
+    image_padded = xp.zeros(toeplitz_kernel.shape, dtype=image.dtype)
+
+    tl_corner = tuple(slice(0, s) for s in image.shape)
+
+    image_padded[tl_corner] = image
+    # 3. FFT convolution
+    tmp = xp.fft.fftn(image_padded)
+    tmp *= toeplitz_kernel
+
+    # 4. Inverse and shift back
+    result = xp.fft.ifftn(tmp)
+    # 5. Crop to original image volume
+    return result[tl_corner]

--- a/src/mrinufft/operators/toeplitz.py
+++ b/src/mrinufft/operators/toeplitz.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from mrinufft._array_compat import with_numpy_cupy, get_array_module
+from mrinufft._utils import proper_trajectory
 
 from mrinufft.operators.base import FourierOperatorBase
 
@@ -45,9 +46,9 @@ def compute_toeplitz_kernel(
     apply_toeplitz_kernel: Apply the Toeplitz kernel to an image.
     """
     xp = get_array_module(nufft.samples)
-    fftn, ifftn = _get_fftn(xp)
+    fftn, _ = _get_fftn(xp)
     backup_density = None
-    if nufft.uses_density:
+    if nufft.density is not None:
         backup_density = nufft.density.copy()
         nufft.density = None
         backup_density_method = nufft._density_method
@@ -73,103 +74,86 @@ def compute_toeplitz_kernel(
         nufft.density = backup_density
         nufft._density_method = backup_density_method
     scale = 1 / nufft.norm_factor
-    return fftn(kernel * scale, overwrite_x=True, norm="ortho")
+    # T = A^H W A is Hermitian for real weights, so its circulant spectrum (the
+    # frequency-domain kernel) is real. Keeping only the real part halves the
+    # kernel memory (dominant in 3D, where it is 2**d the image size) and is
+    # equivalent to enforcing exact Hermitian symmetry of the image-domain kernel.
+    return fftn(kernel * scale, overwrite_x=True, norm="ortho").real
+
+
+def _modulated_weights(
+    weights: NDArray, omega: NDArray, shifts: tuple[int, ...], cpx_dtype
+) -> NDArray:
+    """Fourier-shift the adjoint's lag window by ``shifts`` pixels.
+
+    Modulating the weights by ``exp(i * omega . shifts)`` slides the ``N``-wide
+    window of lags produced by a single ``_adj_op`` onto the ``[N/2, N)`` outer
+    lags, so the full ``2N-1`` support of the Toeplitz kernel is recovered at
+    ``N``-resolution (no extra memory versus a plain adjoint).
+    """
+    xp = get_array_module(weights)
+    shift_vec = xp.asarray(shifts, dtype=omega.dtype)
+    phase = xp.exp(1j * (omega @ shift_vec))
+    return (weights * phase).astype(cpx_dtype, copy=False)
+
+
+def _check_even_shape(shape: tuple[int, ...]) -> None:
+    if any(s % 2 for s in shape):
+        raise ValueError(
+            f"Toeplitz kernel computation only supports even grid sizes, got {shape}."
+        )
 
 
 def _compute_toep_2d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
     xp = get_array_module(nufft.samples)
+    _check_even_shape(nufft.shape)
+    N0, N1 = nufft.shape
+    h0, h1 = N0 // 2, N1 // 2
+    omega = proper_trajectory(nufft.samples, normalize="pi")
 
-    # Trajectory Flipping (Y-axis)
-    samples_orig = nufft.samples.copy()
-    samples_flip_y = samples_orig.copy()
-    samples_flip_y[:, 1] *= -1
-
-    kernel = xp.zeros(tuple(s * 2 for s in nufft.shape), dtype=nufft.cpx_dtype)
+    kernel = xp.zeros((2 * N0, 2 * N1), dtype=nufft.cpx_dtype)
     tmp = xp.empty(nufft.shape, dtype=nufft.cpx_dtype)
 
-    # compute first two quadrants
-    nufft._adj_op(weights, tmp)
-    kernel[: nufft.shape[0], : nufft.shape[1]] = tmp
-    kernel[nufft.shape[0] + 1 :, : nufft.shape[1]] = tmp[:0:-1, :].conj()
+    # Two adjoints cover the positive-x half of the kernel: the y-window is shifted
+    # by +h1 (inner lags) then -h1 (outer lags). Column/row index N is the circulant
+    # "don't-care" slot (never touched by the zero-padded apply), so we skip it.
+    nufft._adj_op(_modulated_weights(weights, omega, (h0, h1), nufft.cpx_dtype), tmp)
+    kernel[:N0, :N1] = tmp
+    nufft._adj_op(_modulated_weights(weights, omega, (h0, -h1), nufft.cpx_dtype), tmp)
+    kernel[:N0, N1 + 1 :] = tmp[:, 1:]
 
-    # flip samples and compute other two quadrants
-    nufft.update_samples(samples_flip_y, unsafe=True)
-    nufft._adj_op(weights, tmp)
-    kernel[: nufft.shape[0], nufft.shape[1] + 1 :] = tmp[:, :0:-1]
-    kernel[nufft.shape[0] + 1 :, nufft.shape[1] + 1 :] = tmp[:0:-1, :0:-1].conj()
-
-    # Restore original samples for nufft object consistency
-    nufft.update_samples(samples_orig, unsafe=True)
-
-    # Enforce strict Hermitian symmetry
-    kernel = (kernel + kernel[::-1, ::-1].conj()) / 2
-
-    # Move the PSF peak from center to [0, 0] to align with corner-padded image
-    # This is more robust than trying to mess with fftshifts and off-by-one errors
-    #
-
-    pos = xp.argmax(xp.abs(kernel))
-    if xp.__name__ == "cupy":
-        pos = pos.get()
-    peak_idx = xp.unravel_index(pos, kernel.shape)
-    kernel = xp.roll(kernel, shift=[-p for p in peak_idx], axis=(0, 1))
-
+    # negative-x half by Hermitian symmetry (c[-d] = conj(c[d]) for real weights)
+    ksym = xp.roll(xp.roll(kernel[::-1, ::-1], 1, axis=0), 1, axis=1).conj()
+    kernel[N0 + 1 :, :] = ksym[N0 + 1 :, :]
     return kernel
 
 
 def _compute_toep_3d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
     xp = get_array_module(nufft.samples)
+    _check_even_shape(nufft.shape)
+    N0, N1, N2 = nufft.shape
+    h0, h1, h2 = N0 // 2, N1 // 2, N2 // 2
+    omega = proper_trajectory(nufft.samples, normalize="pi")
 
-    # Initialize the operator (density=False to get the raw Gram kernel)
-
-    # Prepare Trajectories for 4 octants
-    # We flip Y, Z, and YZ. X is handled by Hermitian symmetry later.
-    samples_orig = nufft.samples.copy()
-
-    samples_z = samples_orig.copy()
-    samples_z[:, 2] *= -1
-
-    samples_y = samples_orig.copy()
-    samples_y[:, 1] *= -1
-
-    samples_yz = samples_orig.copy()
-    samples_yz[:, 1] *= -1
-    samples_yz[:, 2] *= -1
-
-    NX, NY, NZ = nufft.shape
-    kernel = xp.zeros(tuple(s * 2 for s in nufft.shape), dtype=nufft.cpx_dtype)
+    kernel = xp.zeros((2 * N0, 2 * N1, 2 * N2), dtype=nufft.cpx_dtype)
     tmp = xp.empty(nufft.shape, dtype=nufft.cpx_dtype)
 
-    # 2. Compute 4 Adjoints
-    nufft._adj_op(weights, tmp)  # Original
-    kernel[:NX, :NY, :NZ] = tmp
+    # Four adjoints cover the positive-x half; the four sign combinations of the
+    # (y, z) shift recover the inner/outer lags along each axis.
+    def adj(shifts):
+        nufft._adj_op(_modulated_weights(weights, omega, shifts, nufft.cpx_dtype), tmp)
+        return tmp
 
-    nufft.update_samples(samples_z, unsafe=True)
-    nufft._adj_op(weights, tmp)  # Z-flipped
-    kernel[:NX, :NY, NZ + 1 :] = tmp[:, :, :0:-1]
+    kernel[:N0, :N1, :N2] = adj((h0, h1, h2))
+    kernel[:N0, :N1, N2 + 1 :] = adj((h0, h1, -h2))[:, :, 1:]
+    kernel[:N0, N1 + 1 :, :N2] = adj((h0, -h1, h2))[:, 1:, :]
+    kernel[:N0, N1 + 1 :, N2 + 1 :] = adj((h0, -h1, -h2))[:, 1:, 1:]
 
-    nufft.update_samples(samples_y, unsafe=True)
-    nufft._adj_op(weights, tmp)  # Y-flipped
-    kernel[:NX, NY + 1 :, :NZ] = tmp[:, :0:-1, :]
-
-    nufft.update_samples(samples_yz, unsafe=True)
-    nufft._adj_op(weights, tmp)  # YZ-flipped
-    kernel[:NX, NY + 1 :, NZ + 1 :] = tmp[:, :0:-1, :0:-1]
-
-    nufft.update_samples(samples_orig, unsafe=True)
-
-    # fill in the other 4 octants by Hermitian symmetry
-    kernel[NX + 1 :, :, :] = kernel[NX - 1 : 0 : -1, :, :].conj()
-    # Hermitify to ensure symmetry.
-    kernel = (kernel + kernel[::-1, ::-1, ::-1].conj()) / 2
-
-    # Move the PSF peak from center to [0, 0] to align with corner-padded image
-    # This is more robust than trying to mess with fftshifts and off-by-one errors
-    pos = xp.argmax(xp.abs(kernel))
-    if xp.__name__ == "cupy":
-        pos = pos.get()
-    peak_idx = xp.unravel_index(pos, kernel.shape)
-    kernel = xp.roll(kernel, shift=[-p for p in peak_idx], axis=(0, 1, 2))
+    # negative-x half by Hermitian symmetry (c[-d] = conj(c[d]) for real weights)
+    ksym = xp.roll(
+        xp.roll(xp.roll(kernel[::-1, ::-1, ::-1], 1, axis=0), 1, axis=1), 1, axis=2
+    ).conj()
+    kernel[N0 + 1 :] = ksym[N0 + 1 :]
     return kernel
 
 
@@ -218,19 +202,24 @@ def apply_toeplitz_kernel(
 
     if padded_array is None:
         padded_array = xp.zeros((batch_size, *toeplitz_kernel.shape), dtype=image.dtype)
-    elif batch_size == 1 and padded_array.ndim != image.ndim:
-        # expand padded_array to have batch dimension
-        padded_array = padded_array[None, :]
+    else:
+        if batch_size == 1 and padded_array.ndim != image.ndim:
+            # expand padded_array to have batch dimension
+            padded_array = padded_array[None, :]
+        elif padded_array.shape != toeplitz_kernel.shape:
+            raise ValueError("padded_array shape must match toeplitz_kernel shape.")
+        # padded_array is caller-provided scratch memory (e.g. cp.empty, reused
+        # across calls): the padding region is not guaranteed to be zero, so it
+        # must be cleared here or the "zero-padding" invariant the FFT
+        # convolution relies on is silently broken.
+        padded_array[...] = 0
 
-    elif padded_array.shape != toeplitz_kernel.shape:
-        raise ValueError("padded_array shape must match toeplitz_kernel shape.")
-
-    tl_corner = (slice(None),) + tuple(slice(0, s) for s in image.shape)
+    tl_corner = tuple(slice(0, s) for s in image.shape)
 
     # FIXME cannot unpack slice directly in python 3.10
     padded_array[tl_corner] = image
     axis = tuple(range(1, padded_array.ndim))
-    tmp = fftn(padded_array, axes=axis)
+    tmp = fftn(padded_array, axes=axis, overwrite_x=True)
     tmp *= toeplitz_kernel
     result = ifftn(tmp, overwrite_x=True, axes=axis)
 

--- a/src/mrinufft/operators/toeplitz.py
+++ b/src/mrinufft/operators/toeplitz.py
@@ -175,6 +175,7 @@ def apply_toeplitz_kernel(
     image: NDArray,
     toeplitz_kernel: NDArray,
     padded_array: NDArray | None = None,
+    paired_batch: bool = False,
 ) -> NDArray:
     """Apply the 2D or 3D Toeplitz kernel to an image using FFT.
 
@@ -187,6 +188,9 @@ def apply_toeplitz_kernel(
     padded_array : NDArray | None, optional
         An optional pre-allocated array for padding the image. If None,
         a new array will be created. Default is None.
+    paired_batch : bool, optional
+        If True, pairs the batch dimension of the image with the toeplitz_kernel.
+        Default is False, ie the same kernel is applied to all images in the batch.
 
     Returns
     -------
@@ -219,12 +223,13 @@ def apply_toeplitz_kernel(
     elif padded_array.shape != toeplitz_kernel.shape:
         raise ValueError("padded_array shape must match toeplitz_kernel shape.")
 
-    tl_corner = tuple(slice(0, s) for s in image.shape)
+    tl_corner = (slice(None),) + tuple(slice(0, s) for s in image.shape)
 
+    # FIXME cannot unpack slice directly in python 3.10
     padded_array[tl_corner] = image
     axis = tuple(range(1, padded_array.ndim))
     tmp = fftn(padded_array, axes=axis)
     tmp *= toeplitz_kernel
     result = ifftn(tmp, overwrite_x=True, axes=axis)
 
-    return result[tl_corner]
+    return result[tl_corner].reshape(img_shape)

--- a/src/mrinufft/operators/toeplitz.py
+++ b/src/mrinufft/operators/toeplitz.py
@@ -1,17 +1,30 @@
 """Toeplitz approximation of the Auto-adjoint operator for NUFFT."""
 
+from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
 from mrinufft._array_compat import with_numpy_cupy, get_array_module
-from .base import FourierOperatorBase
+
+from mrinufft.operators.base import FourierOperatorBase
 
 
-def calc_toeplitz_kernel(
+def _get_fftn(xp):
+    if xp.__name__ == "numpy":
+        from scipy.fft import fftn, ifftn
+    elif xp.__name__ == "cupy":
+        from cupyx.scipy.fft import fftn, ifftn
+    else:  # fallback for torch and others
+        fftn = xp.fft.fftn
+        ifftn = xp.fft.ifftn
+    return fftn, ifftn
+
+
+def compute_toeplitz_kernel(
     nufft: FourierOperatorBase, weights: NDArray | None = None
 ) -> NDArray:
     """
-    Calculate the Toeplitz kernel for the NUFFT operator.
+    Compute the Toeplitz kernel for the NUFFT operator.
 
     Parameters
     ----------
@@ -29,8 +42,10 @@ def calc_toeplitz_kernel(
 
     See Also
     --------
-    apply_toeplitz: Apply the Toeplitz kernel to an image.
+    apply_toeplitz_kernel: Apply the Toeplitz kernel to an image.
     """
+    xp = get_array_module(nufft.samples)
+    fftn, ifftn = _get_fftn(xp)
     backup_density = None
     if nufft.uses_density:
         backup_density = nufft.density.copy()
@@ -38,15 +53,14 @@ def calc_toeplitz_kernel(
         backup_density_method = nufft._density_method
         nufft._density_method = None
     if weights is None and backup_density is not None:
-        weights = backup_density
+        weights = xp.astype(backup_density, dtype=nufft.cpx_dtype)
     elif weights is None:
-        xp = get_array_module(nufft.samples)
-        weights = xp.ones(nufft.n_samples, dtype=nufft.dtype)
+        weights = xp.ones(nufft.n_samples, dtype=nufft.cpx_dtype)
 
     if nufft.ndim == 2:
-        kernel = _calc_toeplitz_kernel_2d(nufft, weights)
+        kernel = _compute_toep_2d(nufft, weights)
     elif nufft.ndim == 3:
-        kernel = _calc_toeplitz_kernel_3d(nufft, weights)
+        kernel = _compute_toep_3d(nufft, weights)
     else:
         raise ValueError(
             f"Toeplitz kernel calculation not implemented for ndim={nufft.ndim}"
@@ -56,11 +70,11 @@ def calc_toeplitz_kernel(
     if backup_density is not None:
         nufft.density = backup_density
         nufft._density_method = backup_density_method
+    scale = 1 / nufft.norm_factor
+    return fftn(kernel * scale, overwrite_x=True, norm="ortho")
 
-    return kernel
 
-
-def _calc_toeplitz_kernel_2d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
+def _compute_toep_2d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
     xp = get_array_module(nufft.samples)
 
     # Trajectory Flipping (Y-axis)
@@ -68,19 +82,22 @@ def _calc_toeplitz_kernel_2d(nufft: FourierOperatorBase, weights: NDArray) -> ND
     samples_flip_y = samples_orig.copy()
     samples_flip_y[:, 1] *= -1
 
-    k1 = nufft.adj_op(weights)
+    kernel = xp.zeros(tuple(s * 2 for s in nufft.shape), dtype=nufft.cpx_dtype)
+    tmp = xp.empty(nufft.shape, dtype=nufft.cpx_dtype)
+
+    # compute first two quadrants
+    nufft._adj_op(weights, tmp)
+    kernel[: nufft.shape[0], : nufft.shape[1]] = tmp
+    kernel[nufft.shape[0] + 1 :, : nufft.shape[1]] = tmp[:0:-1, :].conj()
+
+    # flip samples and compute other two quadrants
     nufft.update_samples(samples_flip_y, unsafe=True)
-    k2 = nufft.adj_op(weights)
+    nufft._adj_op(weights, tmp)
+    kernel[: nufft.shape[0], nufft.shape[1] + 1 :] = tmp[:, :0:-1]
+    kernel[nufft.shape[0] + 1 :, nufft.shape[1] + 1 :] = tmp[:0:-1, :0:-1].conj()
 
     # Restore original samples for nufft object consistency
     nufft.update_samples(samples_orig, unsafe=True)
-
-    # Assemble Spatial Kernel
-    zero_y = xp.zeros((k1.shape[0], 1), dtype=k1.dtype)
-    ky = xp.concatenate([k1, zero_y, k2[:, :0:-1]], axis=1)
-
-    zero_x = xp.zeros((1, ky.shape[1]), dtype=ky.dtype)
-    kernel = xp.concatenate([ky, zero_x, ky[:0:-1, :].conj()], axis=0)
 
     # Enforce strict Hermitian symmetry
     kernel = (kernel + kernel[::-1, ::-1].conj()) / 2
@@ -88,18 +105,17 @@ def _calc_toeplitz_kernel_2d(nufft: FourierOperatorBase, weights: NDArray) -> ND
     # Move the PSF peak from center to [0, 0] to align with corner-padded image
     # This is more robust than trying to mess with fftshifts and off-by-one errors
     #
-    peak_idx = xp.unravel_index(xp.argmax(xp.abs(kernel)), kernel.shape)
+
+    pos = xp.argmax(xp.abs(kernel))
+    if xp.__name__ == "cupy":
+        pos = pos.get()
+    peak_idx = xp.unravel_index(pos, kernel.shape)
     kernel = xp.roll(kernel, shift=[-p for p in peak_idx], axis=(0, 1))
 
-    # osf is fixed to 2.0
-    # TODO: Generalize to other osf values by cropping / padding ?
-    # what is the relation with the NUFFT osf grid size ?
-    grid_size = xp.prod(xp.array(nufft.shape) * 2)
-    scale = xp.prod(xp.array(kernel.shape)) / grid_size
-    return xp.fft.fftn(kernel * scale)
+    return kernel
 
 
-def _calc_toeplitz_kernel_3d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
+def _compute_toep_3d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
     xp = get_array_module(nufft.samples)
 
     # Initialize the operator (density=False to get the raw Gram kernel)
@@ -118,35 +134,46 @@ def _calc_toeplitz_kernel_3d(nufft: FourierOperatorBase, weights: NDArray) -> ND
     samples_yz[:, 1] *= -1
     samples_yz[:, 2] *= -1
 
+    NX, NY, NZ = nufft.shape
+    kernel = xp.zeros(tuple(s * 2 for s in nufft.shape), dtype=nufft.cpx_dtype)
+    tmp = xp.empty(nufft.shape, dtype=nufft.cpx_dtype)
+
     # 2. Compute 4 Adjoints
-    k00 = nufft.adj_op(weights)  # Original
+    nufft._adj_op(weights, tmp)  # Original
+    kernel[:NX, :NY, :NZ] = tmp
 
     nufft.update_samples(samples_z, unsafe=True)
-    k01 = nufft.adj_op(weights)  # Z-flipped
+    nufft._adj_op(weights, tmp)  # Z-flipped
+    kernel[:NX, :NY, NZ + 1 :] = tmp[:, :, :0:-1]
 
     nufft.update_samples(samples_y, unsafe=True)
-    k10 = nufft.adj_op(weights)  # Y-flipped
+    nufft._adj_op(weights, tmp)  # Y-flipped
+    kernel[:NX, NY + 1 :, :NZ] = tmp[:, :0:-1, :]
 
     nufft.update_samples(samples_yz, unsafe=True)
-    k11 = nufft.adj_op(weights)  # YZ-flipped
+    nufft._adj_op(weights, tmp)  # YZ-flipped
+    kernel[:NX, NY + 1 :, NZ + 1 :] = tmp[:, :0:-1, :0:-1]
 
     nufft.update_samples(samples_orig, unsafe=True)
 
     # 3. Assemble Z-axis (axis 2)
-    zero_z = xp.zeros((*k00.shape[:2], 1), dtype=k00.dtype)
-    kz0 = xp.concatenate([k00, zero_z, k01[:, :, :0:-1]], axis=2)
-    kz1 = xp.concatenate([k10, zero_z, k11[:, :, :0:-1]], axis=2)
 
-    # 4. Assemble Y-axis (axis 1)
-    # flip and conjugate the second half of the Y-assembly relative to Z
-    # but since these are all forward lags, the kyz assembly follows the 2D logic
-    zero_y = xp.zeros((kz0.shape[0], 1, kz0.shape[2]), dtype=kz0.dtype)
-    kyz = xp.concatenate([kz0, zero_y, kz1[:, :0:-1, :]], axis=1)
+    kernel[NX + 1 :, :, :] = kernel[NX - 1 : 0 : -1, :, :].conj()
 
-    # 5. Assemble X-axis using Hermitian symmetry (axis 0)
-    zero_x = xp.zeros((1, *kyz.shape[1:]), dtype=kyz.dtype)
-    # Reflect and conjugate across all dimensions to fill the negative X lags
-    kernel = xp.concatenate([kyz, zero_x, kyz[:0:-1, :, :].conj()], axis=0)
+    # zero_z = xp.zeros((*k00.shape[:2], 1), dtype=k00.dtype)
+    # kz0 = xp.concatenate([k00, zero_z, k01[:, :, :0:-1]], axis=2)
+    # kz1 = xp.concatenate([k10, zero_z, k11[:, :, :0:-1]], axis=2)
+
+    # # 4. Assemble Y-axis (axis 1)
+    # # flip and conjugate the second half of the Y-assembly relative to Z
+    # # but since these are all forward lags, the kyz assembly follows the 2D logic
+    # zero_y = xp.zeros((kz0.shape[0], 1, kz0.shape[2]), dtype=kz0.dtype)
+    # kyz = xp.concatenate([kz0, zero_y, kz1[:, :0:-1, :]], axis=1)
+
+    # # 5. Assemble X-axis using Hermitian symmetry (axis 0)
+    # zero_x = xp.zeros((1, *kyz.shape[1:]), dtype=kyz.dtype)
+    # # Reflect and conjugate across all dimensions to fill the negative X lags
+    # kernel2 = xp.concatenate([kyz, zero_x, kyz[:0:-1, :, :].conj()], axis=0)
 
     # 6. Hermitify to ensure strict symmetry
     kernel = (kernel + kernel[::-1, ::-1, ::-1].conj()) / 2
@@ -158,13 +185,13 @@ def _calc_toeplitz_kernel_3d(nufft: FourierOperatorBase, weights: NDArray) -> ND
         pos = pos.get()
     peak_idx = xp.unravel_index(pos, kernel.shape)
     kernel = xp.roll(kernel, shift=[-p for p in peak_idx], axis=(0, 1, 2))
+    return kernel
 
-    return xp.fft.fftn(kernel)
 
-
-def apply_toeplitz(
+def apply_toeplitz_kernel(
     image: NDArray,
     toeplitz_kernel: NDArray,
+    padded_array: NDArray | None = None,
 ) -> NDArray:
     """Apply the 2D or 3D Toeplitz kernel to an image using FFT.
 
@@ -173,7 +200,10 @@ def apply_toeplitz(
     image : NDArray
         The input 2D or 3D image to which the Toeplitz kernel will be applied.
     toeplitz_kernel : NDArray
-        The 3D Toeplitz kernel in the frequency domain.
+        The 2D or 3D Toeplitz kernel in the frequency domain.
+    padded_array : NDArray | None, optional
+        An optional pre-allocated array for padding the image. If None,
+        a new array will be created. Default is None.
 
     Returns
     -------
@@ -182,20 +212,20 @@ def apply_toeplitz(
 
     See Also
     --------
-    calc_toeplitz_kernel : Calculate the Toeplitz kernel to be used with this function.
+    compute_toeplitz_kernel : Compute Toeplitz kernel to be used with this function.
     """
     xp = get_array_module(image)
-    # Use pre-allocation for speed (Corner Padding)
-    image_padded = xp.zeros(toeplitz_kernel.shape, dtype=image.dtype)
+    fftn, ifftn = _get_fftn(xp)
+    if padded_array is None:
+        padded_array = xp.zeros(toeplitz_kernel.shape, dtype=image.dtype)
+    elif padded_array.shape != toeplitz_kernel.shape:
+        raise ValueError("padded_array shape must match toeplitz_kernel shape.")
 
     tl_corner = tuple(slice(0, s) for s in image.shape)
 
-    image_padded[tl_corner] = image
-    # 3. FFT convolution
-    tmp = xp.fft.fftn(image_padded)
+    padded_array[tl_corner] = image
+    tmp = fftn(padded_array)
     tmp *= toeplitz_kernel
+    result = ifftn(tmp, overwrite_x=True)
 
-    # 4. Inverse and shift back
-    result = xp.fft.ifftn(tmp)
-    # 5. Crop to original image volume
     return result[tl_corner]

--- a/src/mrinufft/operators/toeplitz.py
+++ b/src/mrinufft/operators/toeplitz.py
@@ -57,6 +57,8 @@ def compute_toeplitz_kernel(
     elif weights is None:
         weights = xp.ones(nufft.n_samples, dtype=nufft.cpx_dtype)
 
+    weights = weights.astype(dtype=nufft.cpx_dtype, copy=False)
+
     if nufft.ndim == 2:
         kernel = _compute_toep_2d(nufft, weights)
     elif nufft.ndim == 3:
@@ -216,7 +218,7 @@ def apply_toeplitz_kernel(
 
     if padded_array is None:
         padded_array = xp.zeros((batch_size, *toeplitz_kernel.shape), dtype=image.dtype)
-    elif batch_size == 1 and padded_array.ndim != toeplitz_kernel.ndim:
+    elif batch_size == 1 and padded_array.ndim != image.ndim:
         # expand padded_array to have batch dimension
         padded_array = padded_array[None, :]
 

--- a/src/mrinufft/operators/toeplitz.py
+++ b/src/mrinufft/operators/toeplitz.py
@@ -120,7 +120,7 @@ def _compute_toep_3d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
 
     # Initialize the operator (density=False to get the raw Gram kernel)
 
-    # 1. Prepare Trajectories for 4 octants
+    # Prepare Trajectories for 4 octants
     # We flip Y, Z, and YZ. X is handled by Hermitian symmetry later.
     samples_orig = nufft.samples.copy()
 
@@ -156,26 +156,9 @@ def _compute_toep_3d(nufft: FourierOperatorBase, weights: NDArray) -> NDArray:
 
     nufft.update_samples(samples_orig, unsafe=True)
 
-    # 3. Assemble Z-axis (axis 2)
-
+    # fill in the other 4 octants by Hermitian symmetry
     kernel[NX + 1 :, :, :] = kernel[NX - 1 : 0 : -1, :, :].conj()
-
-    # zero_z = xp.zeros((*k00.shape[:2], 1), dtype=k00.dtype)
-    # kz0 = xp.concatenate([k00, zero_z, k01[:, :, :0:-1]], axis=2)
-    # kz1 = xp.concatenate([k10, zero_z, k11[:, :, :0:-1]], axis=2)
-
-    # # 4. Assemble Y-axis (axis 1)
-    # # flip and conjugate the second half of the Y-assembly relative to Z
-    # # but since these are all forward lags, the kyz assembly follows the 2D logic
-    # zero_y = xp.zeros((kz0.shape[0], 1, kz0.shape[2]), dtype=kz0.dtype)
-    # kyz = xp.concatenate([kz0, zero_y, kz1[:, :0:-1, :]], axis=1)
-
-    # # 5. Assemble X-axis using Hermitian symmetry (axis 0)
-    # zero_x = xp.zeros((1, *kyz.shape[1:]), dtype=kyz.dtype)
-    # # Reflect and conjugate across all dimensions to fill the negative X lags
-    # kernel2 = xp.concatenate([kyz, zero_x, kyz[:0:-1, :, :].conj()], axis=0)
-
-    # 6. Hermitify to ensure strict symmetry
+    # Hermitify to ensure symmetry.
     kernel = (kernel + kernel[::-1, ::-1, ::-1].conj()) / 2
 
     # Move the PSF peak from center to [0, 0] to align with corner-padded image
@@ -216,16 +199,32 @@ def apply_toeplitz_kernel(
     """
     xp = get_array_module(image)
     fftn, ifftn = _get_fftn(xp)
+    img_shape = image.shape
+    if image.ndim == toeplitz_kernel.ndim:
+        # add extra batch dimension
+        image = image[None, ...]
+        batch_size = 1
+    elif image.ndim - 1 == toeplitz_kernel.ndim:
+        batch_size = image.shape[0]
+        toeplitz_kernel = toeplitz_kernel[None, ...]
+    else:
+        raise ValueError("Image and toeplitz_kernel must have compatible dimensions.")
+
     if padded_array is None:
-        padded_array = xp.zeros(toeplitz_kernel.shape, dtype=image.dtype)
+        padded_array = xp.zeros((batch_size, *toeplitz_kernel.shape), dtype=image.dtype)
+    elif batch_size == 1 and padded_array.ndim != toeplitz_kernel.ndim:
+        # expand padded_array to have batch dimension
+        padded_array = padded_array[None, :]
+
     elif padded_array.shape != toeplitz_kernel.shape:
         raise ValueError("padded_array shape must match toeplitz_kernel shape.")
 
     tl_corner = tuple(slice(0, s) for s in image.shape)
 
     padded_array[tl_corner] = image
-    tmp = fftn(padded_array)
+    axis = tuple(range(1, padded_array.ndim))
+    tmp = fftn(padded_array, axes=axis)
     tmp *= toeplitz_kernel
-    result = ifftn(tmp, overwrite_x=True)
+    result = ifftn(tmp, overwrite_x=True, axes=axis)
 
     return result[tl_corner]

--- a/tests/operators/test_batch.py
+++ b/tests/operators/test_batch.py
@@ -243,23 +243,3 @@ def test_pinv_solver(operator, array_interface, image_data, kspace_data, optim):
         assert len(res[0]) == operator.n_batchs
     else:
         assert res[0].ndim == 0
-
-
-@param_array_interface
-def test_interface_gram(operator, array_interface, image_data):
-    """Test the Gram (toeplitz) interface of the operator."""
-    if operator.n_trans != 1:
-        pytest.skip("Gram operator not implemented for n_trans >= 2")
-    image_data_ = to_interface(image_data, array_interface)
-
-    AHA_img = operator.adj_op(operator.op(image_data_))
-    G_img = operator.gram_op(image_data_)
-
-    assert G_img.shape == AHA_img.shape
-
-    AHA_img = from_interface(AHA_img, array_interface)
-    G_img = from_interface(G_img, array_interface)
-
-    # the toeplitz approximation can be quite inaccurate depending on the trajectory
-    # we use a relative mean error metric.
-    assert np.mean(np.abs(AHA_img - G_img) / np.abs(AHA_img)) < 9e-2

--- a/tests/operators/test_batch.py
+++ b/tests/operators/test_batch.py
@@ -261,8 +261,7 @@ def test_interface_gram(operator, array_interface, image_data):
     AHA_img = from_interface(AHA_img, array_interface)
     G_img = from_interface(G_img, array_interface)
 
-    # the toeplitz approximation can be quite inaccurate depending on the trajectory
-    # we use a relative mean error metric.
-    medse = np.median(abs(AHA_img - G_img) ** 2 / abs(G_img) ** 2)
-    print(medse)
-    assert medse < 6e-2
+    # gpunufft is less accurate than the other backends, so we relax the tolerance for it
+    npt.assert_allclose(
+        AHA_img, G_img, rtol=2e-3 if operator.backend == "gpunufft" else 2e-4, atol=1e-4
+    )

--- a/tests/operators/test_batch.py
+++ b/tests/operators/test_batch.py
@@ -59,6 +59,7 @@ def operator(
         smaps += np.random.rand(n_coils, *shape)
         smaps = smaps.astype(np.complex64)
         smaps /= np.linalg.norm(smaps, axis=0)
+        smaps = smaps.astype(np.complex64)
     else:
         smaps = None
     kspace_locs = kspace_locs.astype(np.float32)

--- a/tests/operators/test_batch.py
+++ b/tests/operators/test_batch.py
@@ -243,3 +243,25 @@ def test_pinv_solver(operator, array_interface, image_data, kspace_data, optim):
         assert len(res[0]) == operator.n_batchs
     else:
         assert res[0].ndim == 0
+
+
+@param_array_interface
+def test_interface_gram(operator, array_interface, image_data):
+    """Test the Gram (toeplitz) interface of the operator."""
+    if getattr(operator, "n_trans", 1) >= 2:
+        pytest.skip("Gram operator not implemented for n_trans >= 2")
+
+    image_data_ = to_interface(image_data.copy(), array_interface)
+
+    AHA_img = operator.adj_op(operator.op(image_data_))
+    G_img = operator.gram_op(image_data_)
+    assert G_img.shape == AHA_img.shape
+
+    AHA_img = from_interface(AHA_img, array_interface)
+    G_img = from_interface(G_img, array_interface)
+
+    # the toeplitz approximation can be quite inaccurate depending on the trajectory
+    # we use a relative mean error metric.
+    medse = np.median(abs(AHA_img - G_img) ** 2 / abs(G_img) ** 2)
+    print(medse)
+    assert medse < 6e-2

--- a/tests/operators/test_interfaces.py
+++ b/tests/operators/test_interfaces.py
@@ -206,34 +206,3 @@ def test_check_shape_fail_kspace(operator, array_interface, wrong_kspace_data):
     kspace_data_ = to_interface(wrong_kspace_data, array_interface)
     with pytest.raises(ValueError):
         operator.check_shape(ksp=kspace_data_)
-
-
-@param_array_interface
-def test_interface_gram(operator, array_interface, image_data):
-    """Test the Gram (toeplitz) interface of the operator."""
-    if getattr(operator, "n_trans", 1) >= 2:
-        pytest.skip("Gram operator not implemented for n_trans >= 2")
-
-    # the Toeplitz approximation is not precise on the edges of the image, so
-    # we weights the data to focus on the center of the image.
-    wins = [np.kaiser(s, 14) for s in operator.shape]
-    # outer products of the windows
-    win = np.multiply.outer(wins[0], wins[1])
-    if len(wins) == 3:
-        win = np.multiply.outer(win, wins[2])
-    image_data *= win
-    image_data_ = to_interface(image_data.copy(), array_interface)
-
-    AHA_img = operator.adj_op(operator.op(image_data_))
-    assert np.allclose(from_interface(image_data_, array_interface), image_data.copy())
-    G_img = operator.gram_op(image_data_)
-
-    assert G_img.shape == AHA_img.shape
-
-    AHA_img = from_interface(AHA_img, array_interface)
-    G_img = from_interface(G_img, array_interface)
-
-    # the toeplitz approximation can be quite inaccurate depending on the trajectory
-    # we use a relative mean error metric.
-    nmse = np.median(abs(AHA_img - G_img)) / np.median(abs(G_img))
-    assert nmse < 1e-1


### PR DESCRIPTION
<!---
This is a suggested pull request template for mri-nufft.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://github.com/mind-inria/mri-nufft/blob/master/CONTRIBUTING.md) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #320 
- Replaces #342 


<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- [x] Add a `toeplitz.py` module with function to compute and apply toeplitz kernel
- [x] Add documentation and minimal examples for the interface
- [x] Add a generic `gram_op` method to `FourierOperatorBase` for minimal support
- [x] Add test to compare with naive implementation. 
- [ ] Backend specific implementations (e.g `cufinufft`, `gpunufft` to handle host-device transfers and smaps cachin). *might be addressed in future PRs*


