### PR TITLE
Add TV reconstruction and evaluation metrics to model-based MRI example

### DIFF
--- a/examples/extras/example_recon.py
+++ b/examples/extras/example_recon.py
@@ -60,7 +60,15 @@ y += noise_level * (torch.randn_like(y) + 1j * torch.randn_like(y))
 
 # %%
 # Setup the physics and prior
-physics = fourier_op.make_deepinv_phy()
+physics_complex = fourier_op.make_deepinv_phy()
+
+# With viewed_as_real=True, complex tensors are represented as
+# real-valued tensors with a final dimension of size 2:
+# (..., 2) = (real part, imaginary part).
+physics_real = fourier_op.make_deepinv_phy(viewed_as_real=True)
+
+y_real = torch.view_as_real(y.contiguous())
+
 wavelet = WaveletPrior(
     wv="sym8",
     wvdim=3,
@@ -70,8 +78,7 @@ wavelet = WaveletPrior(
 
 # %%
 # Initial reconstruction with adjoint
-x_dagger = physics.A_dagger(y)
-
+x_dagger = physics_complex.A_dagger(y)
 
 # %%
 # Wavelet reconstruction with FISTA
@@ -123,7 +130,7 @@ wavelet_model = optim_builder(
     max_iter=max_iter,
     params_algo=params_algo,
 )
-x_wavelet = wavelet_model(y, physics)
+x_wavelet = wavelet_model(y, physics_complex)
 
 
 # %%
@@ -145,43 +152,58 @@ x_wavelet = wavelet_model(y, physics)
 # where A is the non-Cartesian MRI forward operator, y is the measured k-space
 # data, and x is the reconstructed image.
 #
-# Since the MRI image is complex-valued, and TVPrior is applied to real-valued
-# tensors here, we apply the TV proximal operator separately to the real and
-# imaginary parts before recombining them.
+# TVPrior is designed for real-valued tensors. With the new
+# `viewed_as_real=True` option, complex MRI data are represented as
+# real-valued tensors with a final dimension of size 2:
+# (..., 2) = (real part, imaginary part).
+# For 3D MRI data, this representation produces 6D tensors of shape
+# (B, C, D, H, W, 2), while DeepInverse TVPrior expects 4D or 5D inputs.
+# We therefore pack the final real/imaginary dimension into the channel
+# dimension before applying TVPrior, and unpack it afterwards.
+# This avoids manually splitting complex tensors into separate real and
+# imaginary TV proximal operations.
+# The TV regularization weight was selected separately using Optuna.
 
+lamb_tv = 0.05789015101052105
 
-class ComplexTVPrior(TVPrior):
-    
-    """TV prior for complex-valued images.
+class RealViewTVPrior(TVPrior):
+    """Adapt TVPrior to tensors represented with torch.view_as_real.
 
-    TVPrior is designed for real-valued tensors. Since MRI reconstructions are
-    complex-valued, we apply the TV prior independently to the real and
-    imaginary parts.
+    This helper packs the final real/imaginary dimension into the channel
+    dimension before applying TV regularization, then restores the original
+    layout afterwards.
     """
+
+    def _pack(self, x):
+        if x.shape[-1] != 2:
+            return x, None
+
+        original_shape = x.shape
+        b, c, *spatial, two = original_shape
+        x = x.movedim(-1, 2)          # (B, C, 2, D, H, W)
+        x = x.reshape(b, c * 2, *spatial)  # (B, 2*C, D, H, W)
+        return x, original_shape
+
+    def _unpack(self, x, original_shape):
+        if original_shape is None:
+            return x
+
+        b, c, *spatial, two = original_shape
+        x = x.reshape(b, c, 2, *spatial)
+        x = x.movedim(2, -1)          # back to (B, C, D, H, W, 2)
+        return x
+
     def prox(self, x, *args, gamma=None, **kwargs):
-        """Apply TV proximal operator separately to real and imaginary parts."""
-
-        if torch.is_complex(x):
-            x_real = super().prox(x.real, *args, gamma=gamma, **kwargs)
-            x_imag = super().prox(x.imag, *args, gamma=gamma, **kwargs)
-            return x_real + 1j * x_imag
-
-        return super().prox(x, *args, gamma=gamma, **kwargs)
+        x_packed, original_shape = self._pack(x)
+        out = super().prox(x_packed, *args, gamma=gamma, **kwargs)
+        return self._unpack(out, original_shape)
 
     def forward(self, x, *args, **kwargs):
-        """Compute TV cost for complex tensors."""
-        if torch.is_complex(x):
-            return super().forward(x.real, *args, **kwargs) + super().forward(
-                x.imag, *args, **kwargs
-            )
-
-        return super().forward(x, *args, **kwargs)
+        x_packed, _ = self._pack(x)
+        return super().forward(x_packed, *args, **kwargs)
 
 
-tv = ComplexTVPrior(n_it_max=20)
-
-# The TV regularization weight was selected separately using Optuna.
-lamb_tv = 0.05789015101052105
+tv = RealViewTVPrior(n_it_max=20)
 
 tv_model = optim_builder(
     iteration="PGD",
@@ -194,7 +216,8 @@ tv_model = optim_builder(
     },
 )
 
-x_tv = tv_model(y, physics)
+x_tv_real = tv_model(y_real, physics_real)
+x_tv = torch.view_as_complex(x_tv_real.contiguous())
 
 # %%
 # Quantitative evaluation

--- a/examples/extras/example_recon.py
+++ b/examples/extras/example_recon.py
@@ -18,10 +18,7 @@ The goal of this example is to illustrate how MRI-NUFFT physics operators can
 be coupled with DeepInverse optimization tools to solve model-based MRI inverse
 problems and compare different regularization priors.
 
-
 """
-
-# %%
 
 # %%
 # Imports
@@ -36,8 +33,6 @@ from mrinufft import get_operator
 from mrinufft.trajectories import initialize_3D_cones
 import torch
 import os
-
-
 
 BACKEND = os.environ.get("MRINUFFT_BACKEND", "cufinufft")
 
@@ -89,7 +84,9 @@ x_dagger = physics.A_dagger(y)
 # The reconstruction minimizes a data-fidelity term together with a wavelet
 # regularization term:
 #
-#     min_x  1/2 || A x - y ||_2^2 + lambda * || W x ||_1
+# .. math::
+#
+#    \min_x \frac{1}{2}\|Ax - y\|_2^2 + \lambda \|Wx\|_1
 #
 # where A is the MRI forward operator, y is the measured k-space data, and W is
 # a wavelet transform. The L2 data-fidelity term enforces consistency with the
@@ -116,7 +113,6 @@ max_iter = 100
 early_stop = True
 
 
-
 # %%
 # Instantiate the algorithm class to solve the problem.
 wavelet_model = optim_builder(
@@ -128,8 +124,6 @@ wavelet_model = optim_builder(
     params_algo=params_algo,
 )
 x_wavelet = wavelet_model(y, physics)
-
-
 
 
 # %%
@@ -144,7 +138,9 @@ x_wavelet = wavelet_model(y, physics)
 #
 # We solve the following variational problem:
 #
-#     min_x  1/2 || A x - y ||_2^2 + lambda * TV(x)
+# .. math::
+#
+#    \min_x \frac{1}{2}\|Ax - y\|_2^2 + \lambda \operatorname{TV}(x)
 #
 # where A is the non-Cartesian MRI forward operator, y is the measured k-space
 # data, and x is the reconstructed image.
@@ -153,35 +149,52 @@ x_wavelet = wavelet_model(y, physics)
 # tensors here, we apply the TV proximal operator separately to the real and
 # imaginary parts before recombining them.
 
-tv = TVPrior(n_it_max=20)
 
-# Regularization and algorithm parameters
+class ComplexTVPrior(TVPrior):
+    
+    """TV prior for complex-valued images.
+
+    TVPrior is designed for real-valued tensors. Since MRI reconstructions are
+    complex-valued, we apply the TV prior independently to the real and
+    imaginary parts.
+    """
+    def prox(self, x, *args, gamma=None, **kwargs):
+        """Apply TV proximal operator separately to real and imaginary parts."""
+
+        if torch.is_complex(x):
+            x_real = super().prox(x.real, *args, gamma=gamma, **kwargs)
+            x_imag = super().prox(x.imag, *args, gamma=gamma, **kwargs)
+            return x_real + 1j * x_imag
+
+        return super().prox(x, *args, gamma=gamma, **kwargs)
+
+    def forward(self, x, *args, **kwargs):
+        """Compute TV cost for complex tensors."""
+        if torch.is_complex(x):
+            return super().forward(x.real, *args, **kwargs) + super().forward(
+                x.imag, *args, **kwargs
+            )
+
+        return super().forward(x, *args, **kwargs)
+
+
+tv = ComplexTVPrior(n_it_max=20)
+
 # The TV regularization weight was selected separately using Optuna.
 lamb_tv = 0.05789015101052105
-stepsize_tv = stepsize
-max_iter_tv = 20
 
-# Initialize with the adjoint reconstruction
-x_tv = physics.A_dagger(y).clone()
+tv_model = optim_builder(
+    iteration="PGD",
+    prior=tv,
+    data_fidelity=data_fidelity,
+    max_iter=20,
+    params_algo={
+        "stepsize": stepsize,
+        "lambda": lamb_tv,
+    },
+)
 
-costs_tv = []
-
-with torch.no_grad():
-    for _ in range(max_iter_tv):
-        # Data-consistency gradient step
-        u = x_tv - stepsize_tv * data_fidelity.grad(x_tv, y, physics)
-
-        # TV proximal step applied separately to real and imaginary parts
-        u_real = tv.prox(u.real, gamma=lamb_tv * stepsize_tv)
-        u_imag = tv.prox(u.imag, gamma=lamb_tv * stepsize_tv)
-
-        # Recombine into a complex-valued image
-        x_tv = u_real + 1j * u_imag
-
-        # Monitor the data-fidelity term
-        data_term = data_fidelity(x_tv, y, physics).item()
-        costs_tv.append(data_term)
-
+x_tv = tv_model(y, physics)
 
 # %%
 # Quantitative evaluation
@@ -240,6 +253,4 @@ for ax, (image, title) in zip(axes, images):
     ax.axis("off")
 
 plt.tight_layout()
-plt.savefig("reconstruction.png", dpi=150, bbox_inches="tight")
-plt.close()
 plt.show()

--- a/examples/extras/example_recon.py
+++ b/examples/extras/example_recon.py
@@ -3,8 +3,21 @@
 Model-based iterative reconstruction
 ====================================
 
-This example demonstrates how to reconstruct image from
-non-Cartesian k-space data with a regularization prior, using deepinv.
+This example demonstrates how to reconstruct a 3D MRI image from undersampled
+non-Cartesian k-space measurements using MRI-NUFFT and DeepInverse.
+
+We first simulate non-Cartesian acquisitions from a reference MRI volume using
+a 3D cones trajectory. We then compare several reconstruction approaches:
+
+1. Adjoint reconstruction, providing a fast baseline with sampling artifacts.
+2. Wavelet-regularized reconstruction solved with FISTA.
+3. Total Variation (TV)-regularized reconstruction solved with proximal
+   gradient descent.
+
+The goal of this example is to illustrate how MRI-NUFFT physics operators can
+be coupled with DeepInverse optimization tools to solve model-based MRI inverse
+problems and compare different regularization priors.
+
 
 """
 
@@ -16,14 +29,15 @@ non-Cartesian k-space data with a regularization prior, using deepinv.
 import numpy as np
 import matplotlib.pyplot as plt
 from brainweb_dl import get_mri
-from deepinv.optim.prior import WaveletPrior
 from deepinv.optim.data_fidelity import L2
 from deepinv.optim.optimizers import optim_builder
-
+from deepinv.optim.prior import WaveletPrior, TVPrior
 from mrinufft import get_operator
 from mrinufft.trajectories import initialize_3D_cones
 import torch
 import os
+
+
 
 BACKEND = os.environ.get("MRINUFFT_BACKEND", "cufinufft")
 
@@ -63,20 +77,49 @@ wavelet = WaveletPrior(
 # Initial reconstruction with adjoint
 x_dagger = physics.A_dagger(y)
 
+
+# %%
+# Wavelet reconstruction with FISTA
+# ---------------------------------
+#
+# The adjoint reconstruction is fast, but it contains artifacts due to
+# undersampling. We therefore solve a regularized inverse problem using a
+# wavelet sparsity prior.
+#
+# The reconstruction minimizes a data-fidelity term together with a wavelet
+# regularization term:
+#
+#     min_x  1/2 || A x - y ||_2^2 + lambda * || W x ||_1
+#
+# where A is the MRI forward operator, y is the measured k-space data, and W is
+# a wavelet transform. The L2 data-fidelity term enforces consistency with the
+# acquired measurements, while the wavelet prior promotes sparse image
+# representations.
+#
+# We use FISTA, an accelerated proximal-gradient algorithm, to solve this
+# optimization problem.
+
+
 # %%
 # Setup and run the reconstruction algorithm
 # Data fidelity term
 data_fidelity = L2()
 # Algorithm parameters
 lamb = 1e1
-stepsize = 0.8 * float(1 / fourier_op.get_lipschitz_cst().get())
+L = fourier_op.get_lipschitz_cst()
+if hasattr(L, "get"):
+    L = L.get()
+
+stepsize = 0.8 / float(L)
 params_algo = {"stepsize": stepsize, "lambda": lamb, "a": 3}
 max_iter = 100
 early_stop = True
 
+
+
 # %%
 # Instantiate the algorithm class to solve the problem.
-wavelet_recon = optim_builder(
+wavelet_model = optim_builder(
     iteration="FISTA",
     prior=wavelet,
     data_fidelity=data_fidelity,
@@ -84,26 +127,119 @@ wavelet_recon = optim_builder(
     max_iter=max_iter,
     params_algo=params_algo,
 )
-x_wavelet = wavelet_recon(y, physics)
+x_wavelet = wavelet_model(y, physics)
+
+
 
 
 # %%
-# Display results
-plt.figure(figsize=(12, 6))
-plt.subplot(1, 3, 1)
-plt.imshow(torch.abs(mri[..., mri.shape[2] // 2 - 5]).cpu(), cmap="gray")
-plt.title("Ground truth")
-plt.axis("off")
-plt.subplot(1, 3, 2)
-plt.imshow(
-    torch.abs(x_dagger[0, 0, ..., x_dagger.shape[2] // 2 - 5]).cpu(), cmap="gray"
-)
-plt.title("Adjoint reconstruction")
-plt.axis("off")
-plt.subplot(1, 3, 3)
-plt.imshow(
-    torch.abs(x_wavelet[0, 0, ..., x_wavelet.shape[2] // 2 - 5]).cpu(), cmap="gray"
-)
-plt.title("Reconstruction with wavelet prior")
-plt.axis("off")
+# Total variation reconstruction with proximal gradient descent
+# ------------------------------------------------------------
+#
+# As an additional model-based reconstruction baseline, we reconstruct the
+# image using a Total Variation (TV) prior. TV regularization promotes images
+# that are piecewise smooth while preserving sharp edges, which is useful in
+# MRI where anatomical structures often have smooth regions separated by
+# boundaries.
+#
+# We solve the following variational problem:
+#
+#     min_x  1/2 || A x - y ||_2^2 + lambda * TV(x)
+#
+# where A is the non-Cartesian MRI forward operator, y is the measured k-space
+# data, and x is the reconstructed image.
+#
+# Since the MRI image is complex-valued, and TVPrior is applied to real-valued
+# tensors here, we apply the TV proximal operator separately to the real and
+# imaginary parts before recombining them.
+
+tv = TVPrior(n_it_max=20)
+
+# Regularization and algorithm parameters
+# The TV regularization weight was selected separately using Optuna.
+lamb_tv = 0.05789015101052105
+stepsize_tv = stepsize
+max_iter_tv = 20
+
+# Initialize with the adjoint reconstruction
+x_tv = physics.A_dagger(y).clone()
+
+costs_tv = []
+
+with torch.no_grad():
+    for _ in range(max_iter_tv):
+        # Data-consistency gradient step
+        u = x_tv - stepsize_tv * data_fidelity.grad(x_tv, y, physics)
+
+        # TV proximal step applied separately to real and imaginary parts
+        u_real = tv.prox(u.real, gamma=lamb_tv * stepsize_tv)
+        u_imag = tv.prox(u.imag, gamma=lamb_tv * stepsize_tv)
+
+        # Recombine into a complex-valued image
+        x_tv = u_real + 1j * u_imag
+
+        # Monitor the data-fidelity term
+        data_term = data_fidelity(x_tv, y, physics).item()
+        costs_tv.append(data_term)
+
+
+# %%
+# Quantitative evaluation
+# -----------------------
+#
+# We evaluate the reconstructions with PSNR and SSIM. PSNR measures the
+# reconstruction fidelity with respect to the reference image: higher PSNR
+# means lower pixel-wise error. SSIM measures structural similarity and is often
+# more informative for images because it compares local contrast and structure.
+#
+# Metrics are computed on magnitude images, since the reconstructions are
+# complex-valued.
+
+
+# %%
+from deepinv.loss.metric import PSNR, SSIM
+
+psnr = PSNR()
+ssim = SSIM()
+
+x_ref = torch.abs(mri).unsqueeze(0).unsqueeze(0)
+x_adjoint_mag = torch.abs(x_dagger)
+x_wavelet_mag = torch.abs(x_wavelet)
+x_tv_mag = torch.abs(x_tv)
+
+print(f"Adjoint PSNR: {psnr(x_adjoint_mag, x_ref).item():.2f}")
+print(f"Wavelet PSNR: {psnr(x_wavelet_mag, x_ref).item():.2f}")
+print(f"TV PSNR: {psnr(x_tv_mag, x_ref).item():.2f}")
+
+print(f"Adjoint SSIM: {ssim(x_adjoint_mag, x_ref).item():.4f}")
+print(f"Wavelet SSIM: {ssim(x_wavelet_mag, x_ref).item():.4f}")
+print(f"TV SSIM: {ssim(x_tv_mag, x_ref).item():.4f}")
+
+
+# %%
+# Visualize the reconstructions
+# -----------------------------
+#
+# We compare the ground-truth image, the adjoint reconstruction, the wavelet
+# reconstruction, and the TV reconstruction on the same slice.
+
+slice_idx = mri.shape[-1] // 2 - 5
+
+fig, axes = plt.subplots(1, 4, figsize=(16, 6))
+
+images = [
+    (torch.abs(mri[..., slice_idx]).detach().cpu(), "Ground truth"),
+    (torch.abs(x_dagger[0, 0, ..., slice_idx]).detach().cpu(), "Adjoint"),
+    (torch.abs(x_wavelet[0, 0, ..., slice_idx]).detach().cpu(), "Wavelet"),
+    (torch.abs(x_tv[0, 0, ..., slice_idx]).detach().cpu(), "TV"),
+]
+
+for ax, (image, title) in zip(axes, images):
+    ax.imshow(image, cmap="gray")
+    ax.set_title(title)
+    ax.axis("off")
+
+plt.tight_layout()
+plt.savefig("reconstruction.png", dpi=150, bbox_inches="tight")
+plt.close()
 plt.show()

--- a/src/mrinufft/operators/autodiff.py
+++ b/src/mrinufft/operators/autodiff.py
@@ -463,27 +463,51 @@ class MRINufftAutoGrad(torch.nn.Module):
         return True
 
 
+def complex_view_wrapper(method):
+    """Handle real-view tensors for complex MRI operators."""
+    def wrapper(self, x: torch.Tensor, **kwargs):
+        if self.viewed_as_real:
+            if x.shape[-1] != 2:
+                raise ValueError(
+                    "When viewed_as_real=True, the last dimension must be 2."
+                )
+            x = torch.view_as_complex(x.contiguous())
+
+        out = method(self, x, **kwargs)
+
+        if self.viewed_as_real:
+            return torch.view_as_real(out)
+
+        return out
+
+    return wrapper
+
+
 class DeepInvPhyNufft(LinearPhysics):
     """Expose an MRINufftAutoGrad as as DeepInv Physics Operator."""
 
-    def __init__(self, autograd_nufft):
+    def __init__(self, autograd_nufft, viewed_as_real=False):
         if not isinstance(autograd_nufft, MRINufftAutoGrad):
             raise ValueError("autograd_nufft should be an instance of MRINufftAutoGrad")
         super().__init__()
         # since autograd_nufft is a nn.Module, we need to set it this way
         # to avoid registering it as a sub-module / parameter.
         self.__dict__["_operator"] = autograd_nufft
+        self.viewed_as_real = viewed_as_real
 
+    @complex_view_wrapper
     def A(self, x: Tensor, **kwargs) -> Tensor:
         """Forward operation."""
         return self._operator.op(x, **kwargs)
 
+    @complex_view_wrapper
     def A_adjoint(self, y: Tensor, **kwargs) -> Tensor:
         """Adjoint operation."""
         return self._operator.adj_op(y, **kwargs)
 
+    @complex_view_wrapper
     def A_dagger(self, y: Tensor, **kwargs) -> Tensor:
-        """Adjoint operation."""
+        """Pseudo-inverse operation."""
         return self._operator.nufft_op.pinv_solver(y, **kwargs)
 
     def __getattr__(self, name):

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -421,8 +421,10 @@ class FourierOperatorBase(ABC):
 
         from mrinufft.operators.autodiff import DeepInvPhyNufft
 
+        viewed_as_real = kwargs.pop("viewed_as_real", False)
+
         autograd_nufft = self.make_autograd(*args, **kwargs)
-        return DeepInvPhyNufft(autograd_nufft)
+        return DeepInvPhyNufft(autograd_nufft, viewed_as_real=viewed_as_real)
 
     def make_autograd(
         self,

--- a/tests/operators/test_autodiff.py
+++ b/tests/operators/test_autodiff.py
@@ -280,6 +280,7 @@ def compute_forward(operator, ksp_data_ref, img_data):
     return ksp_data, ksp_data_ndft
 
 
+
 def compute_forward_batched(operator, ksp_data_ref, img_data):
     """Compute ksps for batched mode."""
     smaps = batched_smaps_from_op(operator)
@@ -294,7 +295,6 @@ def compute_forward_batched(operator, ksp_data_ref, img_data):
         ),
     )
     return ksp_data, ksp_data_ndft
-
 
 @pytest.mark.parametrize("interface", ["torch-gpu", "torch-cpu"])
 @pytest.mark.skipif(not TORCH_AVAILABLE, reason="Pytorch is not installed")
@@ -372,3 +372,31 @@ def test_forward_and_grad(operator, interface):
             grad_nufft_field.cpu().numpy(),
             atol=5e-1,
         )
+
+
+def test_deepinv_phy_nufft_viewed_as_real(operator):
+    """Test DeepInvPhyNufft with viewed_as_real=True."""
+    if operator.backend != "finufft":
+        pytest.skip("CPU-only test for viewed_as_real.")
+
+    physics = operator.nufft_op.make_deepinv_phy(
+        viewed_as_real=True,
+        wrt_data=True,
+        wrt_traj=True,
+        paired_batch=operator.paired_batch,
+    )
+    _, img_data = get_data(operator, "torch-cpu")
+
+    img_real = torch.view_as_real(img_data.contiguous())
+
+    if operator.paired_batch:
+        smaps = batched_smaps_from_op(operator)
+        y_real = physics.A(img_real, smaps=smaps)
+        adj_real = physics.A_adjoint(y_real, smaps=smaps)
+    else:
+        y_real = physics.A(img_real)
+        adj_real = physics.A_adjoint(y_real)
+
+    assert img_real.shape[-1] == 2
+    assert y_real.shape[-1] == 2
+    assert adj_real.shape[-1] == 2


### PR DESCRIPTION
Changes proposed in this pull request:

- Added a Total Variation (TV) reconstruction baseline to the model-based MRI reconstruction example.
- Implemented TV reconstruction using proximal gradient descent.
- Handled complex-valued MRI data by applying the TV proximal operator separately to real and imaginary parts.
- Added quantitative evaluation using PSNR and SSIM metrics.
- Updated visualization to compare ground truth, adjoint, wavelet, and TV reconstructions.

Additional notes:

- The TV regularization parameter was selected empirically (using a separate tuning step).
- Results show that the wavelet prior provides the best reconstruction quality, while TV improves over the adjoint baseline.