### PR TITLE
feat: start mrpro interface

### DIFF
--- a/examples/operators/example_mrpro_interface.py
+++ b/examples/operators/example_mrpro_interface.py
@@ -1,0 +1,51 @@
+"""
+======================================
+MRPro Interface for mri-nufft
+======================================
+
+An example to show how to use the MRPro interface for mri-nufft.
+
+This example demonstrates wrapping an mri-nufft operator as an MRPro
+``LinearOperator``, enabling integration with MRPro's reconstruction algorithms.
+"""
+
+# Authors: mrinufft contributors
+# License: BSD-3-Clause
+
+import numpy as np
+from mrinufft import get_operator
+from mrinufft.trajectories import initialize_2D_spiral
+
+# Generate a simple 2D spiral trajectory
+shape = (32, 32)
+n_shots = 2
+n_samples_per_shot = 256
+samples = initialize_2D_spiral(n_shots, n_samples_per_shot)
+# Flatten and normalize to [-0.5, 0.5]
+samples = samples.reshape(-1, 2) / (2 * np.pi)
+
+# Create a dummy image
+image = np.random.randn(*shape) + 1j * np.random.randn(*shape)
+
+# Generate k-space using mri-nufft
+nufft = get_operator("finufft")(samples=samples, shape=shape)
+kspace = nufft.op(image)
+
+print(f"MRInufft operator created: {nufft}")
+print(f"Backend: {nufft.backend}")
+print(f"Shape: {nufft.shape}")
+print(f"Number of samples: {nufft.n_samples}")
+
+# Wrap the operator for MRPro
+# Note: This requires MRPro to be installed
+try:
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    mrpro_op = MRProNufftInterface(nufft)
+    print(f"\nMRPro LinearOperator created successfully!")
+    print(f"Operator type: {type(mrpro_op)}")
+    print(f"Input type: {mrpro_op.linop.tin}")
+    print(f"Output type: {mrpro_op.linop.tout}")
+except ImportError as e:
+    print(f"\nMRPro not available: {e}")
+    print("Install MRPro to use this interface: pip install mrpro")

--- a/src/mrinufft/_array_compat.py
+++ b/src/mrinufft/_array_compat.py
@@ -65,6 +65,13 @@ except ImportError:
     DEEPINV_AVAILABLE = False
     pass
 
+MRPRO_AVAILABLE = TORCH_AVAILABLE
+
+try:
+    import mrpro  # noqa: F401
+except ImportError:
+    MRPRO_AVAILABLE = False
+
 
 def get_array_module(array: NDArray | Number) -> np:  # type: ignore
     """Get the module of the array."""

--- a/src/mrinufft/operators/autodiff.py
+++ b/src/mrinufft/operators/autodiff.py
@@ -8,7 +8,6 @@ import torch
 import numpy as np
 from .._array_compat import NP2TORCH, _array_to_torch
 from torch.types import Tensor
-from deepinv.physics.forward import LinearPhysics
 
 
 def _backward_op_data(
@@ -461,35 +460,3 @@ class MRINufftAutoGrad(torch.nn.Module):
             )
 
         return True
-
-
-class DeepInvPhyNufft(LinearPhysics):
-    """Expose an MRINufftAutoGrad as as DeepInv Physics Operator."""
-
-    def __init__(self, autograd_nufft):
-        if not isinstance(autograd_nufft, MRINufftAutoGrad):
-            raise ValueError("autograd_nufft should be an instance of MRINufftAutoGrad")
-        super().__init__()
-        # since autograd_nufft is a nn.Module, we need to set it this way
-        # to avoid registering it as a sub-module / parameter.
-        self.__dict__["_operator"] = autograd_nufft
-
-    def A(self, x: Tensor, **kwargs) -> Tensor:
-        """Forward operation."""
-        return self._operator.op(x, **kwargs)
-
-    def A_adjoint(self, y: Tensor, **kwargs) -> Tensor:
-        """Adjoint operation."""
-        return self._operator.adj_op(y, **kwargs)
-
-    def A_dagger(self, y: Tensor, **kwargs) -> Tensor:
-        """Adjoint operation."""
-        return self._operator.nufft_op.pinv_solver(y, **kwargs)
-
-    def __getattr__(self, name):
-        """Get attribute."""
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            operator = super().__getattr__("_operator")
-            return getattr(operator, name)

--- a/src/mrinufft/operators/base.py
+++ b/src/mrinufft/operators/base.py
@@ -23,6 +23,7 @@ from mrinufft._array_compat import (
     get_array_module,
     AUTOGRAD_AVAILABLE,
     DEEPINV_AVAILABLE,
+    MRPRO_AVAILABLE,
     CUPY_AVAILABLE,
     is_cuda_array,
     is_host_array,
@@ -32,12 +33,17 @@ from mrinufft.density import get_density
 from mrinufft.extras import get_smaps
 
 if TYPE_CHECKING:
-    from mrinufft.operators.autodiff import MRINufftAutoGrad, DeepInvPhyNufft
+    from mrinufft.operators.autodiff import MRINufftAutoGrad
+    from mrinufft.operators.outerfaces import (
+        DeepInvPhyNufft,
+        MRProNufftInterface,
+    )
     from mrinufft.operators.stacked import MRIStackedNUFFT, MRIStackedNUFFTGPU
     from mrinufft.operators.off_resonance import MRIFourierCorrected
 else:
     MRIFourierCorrected = Any  # type: ignore
     DeepInvPhyNufft = Any  # type: ignore
+    MRProNufftInterface = Any  # type: ignore
     MRINufftAutoGrad = Any  # type: ignore
     MRIStackedNUFFT = Any  # type: ignore
     MRIStackedNUFFTGPU = Any  # type: ignore
@@ -361,31 +367,9 @@ class FourierOperatorBase(ABC):
         - https://docs.cupy.dev/en/stable/reference/generated/cupyx.scipy.sparse.linalg.LinearOperator.html
         - https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html
         """
-        if cupy and not CUPY_AVAILABLE:
-            raise ValueError("cupy is not available")
-        elif cupy:
-            from cupyx.scipy.sparse.linalg import LinearOperator
-        else:
-            from scipy.sparse.linalg import LinearOperator
+        from .outerfaces import ScipyLinearOperatorInterface
 
-        linop = LinearOperator(
-            shape=(
-                self.n_batchs * self.n_coils * self.n_samples,
-                self.n_batchs
-                * (1 if self.uses_sense else self.n_coils)
-                * np.prod(self.shape),
-            ),
-            matvec=lambda x: self.op(  # type: ignore
-                x.reshape(
-                    self.n_batchs, (1 if self.uses_sense else self.n_coils), *self.shape
-                )
-            ).ravel(),
-            rmatvec=lambda x: self.adj_op(  # type: ignore
-                x.reshape(self.n_batchs, self.n_coils, self.n_samples)
-            ).ravel(),
-            dtype=self.cpx_dtype,
-        )
-        linop._nufft = self  # type: ignore
+        return ScipyLinearOperatorInterface(self, cupy=cupy)
 
     def make_deepinv_phy(self, *args, **kwargs) -> DeepInvPhyNufft:
         """Make a new DeepInv Physics with NUFFT operator.
@@ -398,20 +382,18 @@ class FourierOperatorBase(ABC):
         wrt_traj : bool, optional
             If the gradient with respect to the trajectory is computed, default is false
 
-        paired_batch : int, optional
-            If provided, specifies batch size for varying data/smaps pairs.
-            Default is None, which means no batching
+        paired_batch : bool, optional
+            If True, use paired batched data/smaps. Default is False.
 
         Returns
         -------
-        torch.nn.module
-            A NUFFT operator with autodiff capabilities.
+        DeepInvPhyNufft
+            A DeepInv Physics object wrapping the NUFFT operator with autodiff.
 
         Raises
         ------
         ValueError
-            If autograd is not available.
-
+            If DeepInv or autograd is not available.
 
         """
         if not (DEEPINV_AVAILABLE & AUTOGRAD_AVAILABLE):
@@ -419,10 +401,45 @@ class FourierOperatorBase(ABC):
         if not self.autograd_available:
             raise ValueError("Backend does not support auto-differentiation.")
 
-        from mrinufft.operators.autodiff import DeepInvPhyNufft
+        from mrinufft.operators.outerfaces import DeepInvPhyNufft
 
         autograd_nufft = self.make_autograd(*args, **kwargs)
         return DeepInvPhyNufft(autograd_nufft)
+
+    def make_mrpro(self, *args, **kwargs) -> MRProNufftInterface:
+        """Make a new MRPro LinearOperator with NUFFT operator.
+
+        Parameters
+        ----------
+        wrt_data : bool, optional
+            If the gradient with respect to the data is computed, default is true
+
+        wrt_traj : bool, optional
+            If the gradient with respect to the trajectory is computed, default is false
+
+        paired_batch : bool, optional
+            If True, use paired batched data/smaps. Default is False.
+
+        Returns
+        -------
+        mrpro.algorithms.LinearOperator
+            A NUFFT operator compatible with MRPro.
+
+        Raises
+        ------
+        ValueError
+            If MRPro or autograd is not available.
+        """
+        if not (MRPRO_AVAILABLE & AUTOGRAD_AVAILABLE):
+            raise ValueError(
+                "MRPro not available, ensure mrpro and torch are installed."
+            )
+        if not self.autograd_available:
+            raise ValueError("Backend does not support auto-differentiation.")
+
+        from mrinufft.operators.outerfaces import MRProNufftInterface
+
+        return MRProNufftInterface(self, *args, **kwargs)
 
     def make_autograd(
         self,
@@ -439,9 +456,8 @@ class FourierOperatorBase(ABC):
             If the gradient with respect to the data is computed, default is true
         wrt_traj : bool, optional
             If the gradient with respect to the trajectory is computed, default is false
-        paired_batch : int, optional
-            If provided, specifies batch size for varying data/smaps pairs.
-            Default is None, which means no batching
+        paired_batch : bool, optional
+            If True, use paired batched data/smaps. Default is False.
 
         Returns
         -------

--- a/src/mrinufft/operators/off_resonance.py
+++ b/src/mrinufft/operators/off_resonance.py
@@ -14,7 +14,8 @@ from ..extras.field_map import get_orc_factorization, get_complex_fieldmap_rad
 from .base import FourierOperatorBase, power_method, get_operator, AUTOGRAD_AVAILABLE
 
 if TYPE_CHECKING:
-    from mrinufft.operators.autodiff import MRINufftAutoGrad, DeepInvPhyNufft
+    from mrinufft.operators.autodiff import MRINufftAutoGrad
+    from mrinufft.operators.outerfaces import DeepInvPhyNufft
 else:
     MRINufftAutoGrad = None
     DeepInvPhyNufft = None

--- a/src/mrinufft/operators/outerfaces.py
+++ b/src/mrinufft/operators/outerfaces.py
@@ -106,7 +106,6 @@ class DeepInvPhyNufft:
         if not isinstance(autograd_nufft, MRINufftAutoGrad):
             raise ValueError("autograd_nufft should be an instance of MRINufftAutoGrad")
 
-        self.__class__.__bases__ = (LinearPhysics,)
         LinearPhysics.__init__(self)
 
         # Avoid nn.Module registration

--- a/src/mrinufft/operators/outerfaces.py
+++ b/src/mrinufft/operators/outerfaces.py
@@ -1,0 +1,242 @@
+"""Framework wrapper interfaces (Deepinv, MRPro).
+
+This module provides thin wrapper classes that expose mri-nufft operators
+as first-class citizens in popular imaging frameworks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+from mrinufft.operators.base import FourierOperatorBase
+from mrinufft._array_compat import (
+    CUPY_AVAILABLE,
+    MRPRO_AVAILABLE,
+    NP2TORCH,
+    _array_to_torch,
+    AUTOGRAD_AVAILABLE,
+    DEEPINV_AVAILABLE,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+
+class ScipyLinearOperatorInterface:
+    """Expose an mri-nufft operator as a SciPy/Cupy LinearOperator.
+
+    Parameters
+    ----------
+    nufft_op : FourierOperatorBase
+        A non-differentiable mri-nufft operator instance.
+
+    Notes
+    -----
+    This wrapper allows the mri-nufft operator to be used with SciPy's sparse
+    linear algebra routines, such as iterative solvers.
+    """
+
+    def __init__(self, nufft_op, cupy: bool = False):
+        if not isinstance(nufft_op, FourierOperatorBase):
+            raise ValueError("nufft_op should be an instance of FourierOperatorBase")
+        self._nufft = nufft_op
+
+        if cupy and not CUPY_AVAILABLE:
+            raise ValueError("cupy is not available")
+        elif cupy:
+            from cupyx.scipy.sparse.linalg import LinearOperator
+        else:
+            from scipy.sparse.linalg import LinearOperator
+
+        # Build input shape: (batch, coil, *shape)
+        ishape = self._nufft.img_full_shape
+        # Build output shape: (batch, coil, n_samples)
+        oshape = self._nufft.ksp_full_shape
+
+        # Initialize SciPy LinearOperator
+        LinearOperator.__init__(
+            self,
+            dtype=np.complex64,
+            shape=(np.prod(oshape), np.prod(ishape)),
+            matvec=self._matvec,
+            rmatvec=self._rmatvec,
+        )
+        self._nufft = nufft_op
+
+    def _matvec(self, x):
+        """Forward operation (image -> k-space)."""
+        x_reshaped = x.reshape(self._nufft.img_full_shape)
+        return self._nufft.op(x_reshaped).ravel()
+
+    def _rmatvec(self, y):
+        """Adjoint operation (k-space -> image)."""
+        y_reshaped = y.reshape(self._nufft.ksp_full_shape)
+        return self._nufft.adj_op(y_reshaped).ravel()
+
+
+class DeepInvPhyNufft:
+    """Expose an MRINufftAutoGrad as a DeepInv Physics Operator.
+
+    Parameters
+    ----------
+    autograd_nufft : MRINufftAutoGrad
+        An mri-nufft operator wrapped with autograd support.
+
+    Notes
+    -----
+    Since `autograd_nufft` is a ``nn.Module``, it is stored via ``__dict__``
+    to avoid registering it as a sub-module / parameter of the DeepInv
+    physics object.
+    """
+
+    def __init__(self, autograd_nufft):
+        try:
+            from deepinv.physics.forward import LinearPhysics
+        except ImportError:
+            raise ImportError(
+                "DeepInv is not installed. Install it with: pip install deepinv"
+            ) from None
+
+        from mrinufft.operators.autodiff import MRINufftAutoGrad
+
+        if not isinstance(autograd_nufft, MRINufftAutoGrad):
+            raise ValueError("autograd_nufft should be an instance of MRINufftAutoGrad")
+
+        self.__class__.__bases__ = (LinearPhysics,)
+        LinearPhysics.__init__(self)
+
+        # Avoid nn.Module registration
+        self.__dict__["_operator"] = autograd_nufft
+
+    def A(self, x, **kwargs):
+        """Forward operation (image -> k-space)."""
+        return self._operator.op(x, **kwargs)
+
+    def A_adjoint(self, y, **kwargs):
+        """Adjoint operation (k-space -> image)."""
+        return self._operator.adj_op(y, **kwargs)
+
+    def A_dagger(self, y, **kwargs):
+        """Pseudo-inverse operation (k-space -> image)."""
+        return self._operator.nufft_op.pinv_solver(y, **kwargs)
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the underlying autograd operator."""
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            operator = super().__getattr__("_operator")
+            return getattr(operator, name)
+
+
+class MRProNufftInterface:
+    """Expose an mri-nufft operator as an MRPro LinearOperator.
+
+    Parameters
+    ----------
+    nufft_op : FourierOperatorBase
+        A non-differentiable mri-nufft operator instance.
+    wrt_data : bool, default True
+        If True, enable gradient computation with respect to image data.
+    wrt_traj : bool, default False
+        If True, enable gradient computation with respect to trajectory samples.
+    paired_batch : bool, default False
+        If True, support paired batched data/smaps.
+
+    Notes
+    -----
+    MRPro's ``LinearOperator`` inherits from ``Operator[Tin, tuple[Tout]]``
+    with ``adjoint_as_backward=True``. Since MRPro's ``Operator.forward()``
+    expects the output to be returned as a tuple, this wrapper automatically
+    wraps the k-space output in a single-element tuple.
+    """
+
+    def __init__(
+        self,
+        nufft_op: FourierOperatorBase,
+        wrt_data: bool = True,
+        wrt_traj: bool = False,
+        paired_batch: bool = False,
+    ):
+        if not MRPRO_AVAILABLE:
+            raise ImportError(
+                "MRPro is not installed. Install it with: pip install mrpro"
+            ) from None
+
+        if not AUTOGRAD_AVAILABLE:
+            raise ImportError(
+                "PyTorch is not installed. Install it with: pip install torch"
+            ) from None
+
+        if not nufft_op.autograd_available:
+            raise ValueError(
+                f"Backend '{nufft_op.backend}' does not support auto-differentiation."
+            )
+
+        from mrinufft.operators.autodiff import MRINufftAutoGrad
+
+        self._nufft = nufft_op
+        self._autograd = nufft_op.make_autograd(
+            wrt_data=wrt_data, wrt_traj=wrt_traj, paired_batch=paired_batch
+        )
+
+        # MRPro LinearOperator base class
+        from mrpro.algorithms.linear_operator import LinearOperator
+
+        # Build input shape: (batch, coil, *shape)
+        ishape = self._nufft.img_full_shape
+        # Build output shape: (batch, coil, n_samples)
+        oshape = self._nufft.ksp_full_shape
+
+        # Initialize MRPro LinearOperator
+        LinearOperator.__init__(
+            self,
+            ishape=ishape,
+            oshape=oshape,
+        )
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        """Forward operation (image -> k-space).
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Image data.
+
+        Returns
+        -------
+        tuple[torch.Tensor]
+            A single-element tuple containing k-space data.
+        """
+        kspace = self._autograd.op(x)
+        return (kspace,)
+
+    def adjoint(self, y: tuple[torch.Tensor]) -> torch.Tensor:
+        """Adjoint operation (k-space -> image).
+
+        Parameters
+        ----------
+        y : tuple[torch.Tensor]
+            A single-element tuple containing k-space data.
+
+        Returns
+        -------
+        torch.Tensor
+            Reconstructed image data.
+        """
+        kspace = y[0]
+        return self._autograd.adj_op(kspace)
+
+    @property
+    def ishape(self):
+        """Input shape (image space)."""
+        return self._nufft.img_full_shape
+
+    @property
+    def oshape(self):
+        """Output shape (k-space)."""
+        return self._nufft.ksp_full_shape

--- a/tests/operators/test_outerfaces.py
+++ b/tests/operators/test_outerfaces.py
@@ -1,0 +1,158 @@
+"""Test the outerfaces (MRPro, DeepInv) interfaces."""
+
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+from pytest_cases import parametrize_with_cases, parametrize, fixture
+from case_trajectories import CasesTrajectories
+from mrinufft.operators import get_operator
+from mrinufft._array_compat import MRPRO_AVAILABLE, AUTOGRAD_AVAILABLE
+
+TORCH_AVAILABLE = True
+try:
+    import torch
+except ImportError:
+    TORCH_AVAILABLE = False
+
+
+@fixture(scope="module")
+@parametrize(backend=["finufft"])
+@parametrize_with_cases(
+    "kspace_loc, shape",
+    cases=[
+        CasesTrajectories.case_grid2D,
+        CasesTrajectories.case_nyquist_radial2D,
+    ],
+)
+def operator(kspace_loc: NDArray, shape: tuple[int, ...], backend: str):
+    """Create NUFFT operator for outerface tests."""
+    kspace_loc = kspace_loc.astype(np.float32)
+    return get_operator(backend_name=backend)(
+        samples=kspace_loc,
+        shape=shape,
+        squeeze_dims=False,
+    )
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+@pytest.mark.skipif(not MRPRO_AVAILABLE, reason="MRPro is not installed")
+def test_mrpro_interface_forward(operator):
+    """Test MRPro interface forward pass."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    mrpro_op = MRProNufftInterface(operator)
+
+    # Create image data
+    img_shape = operator.img_full_shape
+    image = np.random.randn(*img_shape) + 1j * np.random.randn(*img_shape)
+    image_torch = torch.from_numpy(image).to(torch.complex64)
+
+    # Forward pass
+    kspace_tuple = mrpro_op.forward(image_torch)
+
+    # Check output is a tuple
+    assert isinstance(kspace_tuple, tuple)
+    assert len(kspace_tuple) == 1
+
+    # Check shape
+    expected_ksp_shape = operator.ksp_full_shape
+    assert kspace_tuple[0].shape == expected_ksp_shape
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+@pytest.mark.skipif(not MRPRO_AVAILABLE, reason="MRPro is not installed")
+def test_mrpro_interface_adjoint(operator):
+    """Test MRPro interface adjoint pass."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    mrpro_op = MRProNufftInterface(operator)
+
+    # Create k-space data
+    ksp_shape = operator.ksp_full_shape
+    kspace = np.random.randn(*ksp_shape) + 1j * np.random.randn(*ksp_shape)
+    kspace_torch = torch.from_numpy(kspace).to(torch.complex64)
+
+    # Adjoint pass
+    image = mrpro_op.adjoint((kspace_torch,))
+
+    # Check shape
+    expected_img_shape = operator.img_full_shape
+    assert image.shape == expected_img_shape
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+@pytest.mark.skipif(not MRPRO_AVAILABLE, reason="MRPro is not installed")
+def test_mrpro_interface_consistency(operator):
+    """Test MRPro interface forward/adjoint consistency."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    mrpro_op = MRProNufftInterface(operator)
+
+    # Create image data
+    img_shape = operator.img_full_shape
+    image = np.random.randn(*img_shape) + 1j * np.random.randn(*img_shape)
+    image_torch = torch.from_numpy(image).to(torch.complex64)
+
+    # Forward pass
+    kspace_tuple = mrpro_op.forward(image_torch)
+
+    # Adjoint pass
+    image_reconstructed = mrpro_op.adjoint(kspace_tuple)
+
+    # Check shapes match
+    assert image_reconstructed.shape == image_torch.shape
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+@pytest.mark.skipif(not MRPRO_AVAILABLE, reason="MRPro is not installed")
+def test_mrpro_interface_ishape_oshape(operator):
+    """Test MRPro interface ishape and oshape properties."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    mrpro_op = MRProNufftInterface(operator)
+
+    assert mrpro_op.ishape == operator.img_full_shape
+    assert mrpro_op.oshape == operator.ksp_full_shape
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+def test_mrpro_interface_structure():
+    """Test MRPro interface has expected methods."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    assert hasattr(MRProNufftInterface, "forward")
+    assert hasattr(MRProNufftInterface, "adjoint")
+    assert hasattr(MRProNufftInterface, "make")
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+def test_mrpro_make_classmethod(operator):
+    """Test MRPro interface make classmethod."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    if not MRPRO_AVAILABLE:
+        pytest.skip("MRPro is not installed")
+
+    mrpro_op = MRProNufftInterface.make(operator)
+    assert isinstance(mrpro_op, MRProNufftInterface)
+
+
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
+def test_mrpro_no_autograd_error(operator):
+    """Test error when backend does not support autograd."""
+    from mrinufft.operators.outerfaces import MRProNufftInterface
+
+    if not MRPRO_AVAILABLE:
+        pytest.skip("MRPro is not installed")
+
+    # Create an operator that doesn't support autograd
+    # The finufft backend should support autograd, so we need to mock it
+    class FakeOperator:
+        autograd_available = False
+        img_full_shape = (1, 1, 32, 32)
+        ksp_full_shape = (1, 1, 512)
+
+    fake_op = FakeOperator()
+
+    with pytest.raises(ValueError, match="does not support auto-differentiation"):
+        MRProNufftInterface(fake_op)


### PR DESCRIPTION
<!---
This is a suggested pull request template for mri-nufft.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://github.com/mind-inria/mri-nufft/blob/master/CONTRIBUTING.md) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #379 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- [x] Create a `outerface.py` module for hosting all the wrapper classes for external libraries (scipy `LinearOperator`, `deepinv`, `mrpro`, ...)
- [ ] Write an example showcasing usage in MRPro 
- [ ] Setup test environment for MRPro


NB: this is also myself tipping a toe in "agentic engineering", so extra pair of eyes might be needed.
