### PR TITLE
Fast import 

### DIFF
--- a/src/mrinufft/__init__.py
+++ b/src/mrinufft/__init__.py
@@ -6,19 +6,35 @@ reconstruction.
 Doing non-Cartesian MRI has never been so easy.
 """
 
-from . import display, trajectories, operators, density, extras, io
+import importlib as _importlib
+from typing import TYPE_CHECKING
 
-from mrinufft.operators import get_operator
+submodules = ["display", "trajectories", "operators", "density", "extras", "io"]
 
-__all__ = [
-    "display",
-    "trajectories",
-    "operators",
-    "density",
-    "extras",
-    "io",
-    "get_operator",
-]
+__all__ = submodules + ["get_operator", "__version__"]
+
+
+def __getattr__(name):
+    """Lazily import submodules on first access (PEP 562)."""
+    if name in submodules:
+        return _importlib.import_module(f"mrinufft.{name}")
+    if name == "get_operator":
+        return _importlib.import_module("mrinufft.operators").get_operator
+    try:
+        return globals()[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+
+def __dir__():
+    return __all__
+
+
+if TYPE_CHECKING:
+    # Static visibility for the one re-exported symbol; the submodules above
+    # are real packages and resolve without help.
+    from mrinufft.operators import get_operator
+
 
 from importlib.metadata import version, PackageNotFoundError
 

--- a/src/mrinufft/_array_compat.py
+++ b/src/mrinufft/_array_compat.py
@@ -1,78 +1,98 @@
 """Array libraries compatibility utils."""
 
+from __future__ import annotations
+
+import importlib.util
 import warnings
-from numbers import Number  # abstract base type for python numeric type
-from functools import wraps, partial
+from functools import partial, wraps
 from inspect import cleandoc
-from numpy.typing import NDArray, DTypeLike
+from numbers import Number  # abstract base type for python numeric type
+from typing import Any
+
 import numpy as np
-
-ARRAY_LIBS = {
-    "numpy": (np, np.ndarray),
-    "cupy": (None, None),
-    "torch": (None, None),
-    "tensorflow": (None, None),
-}
-
-ArrayTypes = np.ndarray
-# TEST import of array libraries.
-
-TENSORFLOW_AVAILABLE = True
-CUPY_AVAILABLE = True
-AUTOGRAD_AVAILABLE = True
-TORCH_AVAILABLE = True
-
-try:
-    import cupy as cp
-
-    ARRAY_LIBS["cupy"] = (cp, cp.ndarray)
-    ArrayTypes = ArrayTypes | cp.ndarray
-except ImportError:
-    CUPY_AVAILABLE = False
-
-try:
-    import torch
-
-    ARRAY_LIBS["torch"] = (torch, torch.Tensor)
-    ArrayTypes = ArrayTypes | torch.Tensor
-except ImportError:
-    AUTOGRAD_AVAILABLE = False
-    TORCH_AVAILABLE = False
-    pass
-    NP2TORCH = {}
-else:
-    NP2TORCH = {
-        np.dtype("float64"): torch.float64,
-        np.dtype("float32"): torch.float32,
-        np.dtype("complex64"): torch.complex64,
-        np.dtype("complex128"): torch.complex128,
-    }
-try:
-    import tensorflow as tf
-    from tensorflow.experimental import numpy as tnp
-
-    ARRAY_LIBS["tensorflow"] = (tnp, tnp.ndarray)
-    ArrayTypes = ArrayTypes | tnp.ndarray
-except ImportError:
-    TENSORFLOW_AVAILABLE = False
-    pass
-
-DEEPINV_AVAILABLE = TORCH_AVAILABLE
-
-try:
-    from deepinv.physics.forward import LinearPhysics
-except ImportError:
-    DEEPINV_AVAILABLE = False
-    pass
+from numpy.typing import DTypeLike, NDArray
 
 
-def get_array_module(array: NDArray | Number) -> np:  # type: ignore
-    """Get the module of the array."""
+def _module_available(name: str) -> bool:
+    """Check availability of an optional dependency without importing it."""
+    return importlib.util.find_spec(name) is not None
+
+
+CUPY_AVAILABLE = _module_available("cupy")
+TORCH_AVAILABLE = _module_available("torch")
+AUTOGRAD_AVAILABLE = TORCH_AVAILABLE
+TENSORFLOW_AVAILABLE = _module_available("tensorflow")
+DEEPINV_AVAILABLE = TORCH_AVAILABLE and _module_available("deepinv")
+
+_ARRAY_NAMESPACES = ("numpy", "cupy", "torch", "tensorflow")
+
+
+def is_array(x: Any) -> bool:
+    """Return True if x is a numpy/cupy/torch/tensorflow array (not a np scalar)."""
+    return (
+        not isinstance(x, np.generic) and _get_array_module_name(x) in _ARRAY_NAMESPACES
+    )
+
+
+_NP2TORCH = None
+_TF_CUDA_AVAILABLE = None
+
+
+def _np2torch():
+    """Lazily build and cache the numpy->torch dtype mapping."""
+    global _NP2TORCH
+    if _NP2TORCH is None:
+        import torch
+
+        _NP2TORCH = {
+            np.dtype("float64"): torch.float64,
+            np.dtype("float32"): torch.float32,
+            np.dtype("complex64"): torch.complex64,
+            np.dtype("complex128"): torch.complex128,
+        }
+    return _NP2TORCH
+
+
+def _tf_cuda_is_available():
+    """Check (and cache) whether Tensorflow has CUDA support."""
+    global _TF_CUDA_AVAILABLE
+    if _TF_CUDA_AVAILABLE is None:
+        if TENSORFLOW_AVAILABLE:
+            import tensorflow as tf
+
+            devices = tf.config.list_physical_devices()
+            _TF_CUDA_AVAILABLE = "GPU" in [d.device_type for d in devices]
+        else:
+            _TF_CUDA_AVAILABLE = False
+    return _TF_CUDA_AVAILABLE
+
+
+def __getattr__(name):
+    """Expose lazily-computed values as module attributes (PEP 562)."""
+    if name == "NP2TORCH":
+        return _np2torch()
+    if name == "TF_CUDA_AVAILABLE":
+        return _tf_cuda_is_available()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def _get_array_module_name(array) -> str:
+    return type(array).__module__.partition(".")[0]
+
+
+def get_array_module(array):
+    """Get the array module (numpy/cupy/torch/tnp) of an array."""
     if isinstance(array, Number | np.generic):
         return np
-    for lib, array_type in ARRAY_LIBS.values():
-        if lib is not None and isinstance(array, array_type):
-            return lib
+    root = _get_array_module_name(array)
+    if root == "numpy":
+        return np
+    if root in ("cupy", "torch"):
+        return importlib.import_module(root)
+    if root == "tensorflow":
+        from tensorflow.experimental import numpy as tnp
+
+        return tnp
     raise ValueError(f"Unknown array library (={type(array)}.")
 
 
@@ -81,24 +101,9 @@ def auto_cast(array, dtype: DTypeLike):
 
     This automatically convert numpy/torch dtype to suitable format.
     """
-    module = get_array_module(array)
-    if module.__name__ == "torch":
-        return array.to(NP2TORCH[np.dtype(dtype)], copy=False)
-    else:
-        return array.astype(dtype, copy=False)
-
-
-def _tf_cuda_is_available():
-    """Check whether Tensorflow has CUDA support or not."""
-    if TENSORFLOW_AVAILABLE:
-        devices = tf.config.list_physical_devices()
-        device_type = [device.device_type for device in devices]
-        return "GPU" in device_type
-    else:
-        return False
-
-
-TF_CUDA_AVAILABLE = _tf_cuda_is_available()
+    if _get_array_module_name(array) == "torch":
+        return array.to(_np2torch()[np.dtype(dtype)], copy=False)
+    return array.astype(dtype, copy=False)
 
 
 def is_cuda_array(var) -> bool:
@@ -109,12 +114,12 @@ def is_cuda_array(var) -> bool:
         return False
 
 
-def is_cuda_tensor(var: ArrayTypes) -> bool:
+def is_cuda_tensor(var: Any) -> bool:
     """Check if var is a CUDA tensor."""
-    return TORCH_AVAILABLE and isinstance(var, torch.Tensor) and var.is_cuda
+    return _get_array_module_name(var) == "torch" and var.is_cuda
 
 
-def is_host_array(var: ArrayTypes) -> bool:
+def is_host_array(var: Any) -> bool:
     """Check if var is a host contiguous np array."""
     try:
         if isinstance(var, np.ndarray):
@@ -129,6 +134,8 @@ def is_host_array(var: ArrayTypes) -> bool:
 
 def pin_memory(array: NDArray) -> NDArray:
     """Create a copy of the array in pinned memory."""
+    import cupy as cp
+
     mem = cp.cuda.alloc_pinned_memory(array.nbytes)
     ret = np.frombuffer(mem, array.dtype, array.size).reshape(array.shape)
     ret[...] = array
@@ -250,6 +257,8 @@ def _array_to_numpy(_arg):
     if xp.__name__ == "torch":
         _arg = _arg.numpy(force=True)
     elif xp.__name__ == "cupy":
+        import cupy as cp
+
         _arg = cp.asnumpy(_arg)
     elif "tensorflow" in xp.__name__:
         _arg = _arg.numpy()
@@ -258,6 +267,8 @@ def _array_to_numpy(_arg):
 
 def _array_to_cupy(_arg, device=None):
     """Convert array to Cupy."""
+    import cupy as cp
+
     xp = get_array_module(_arg)
     if xp.__name__ == "numpy":
         with cp.cuda.Device(device):
@@ -271,6 +282,8 @@ def _array_to_cupy(_arg, device=None):
         else:
             _arg = cp.from_dlpack(_arg)
     elif "tensorflow" in xp.__name__:
+        import tensorflow as tf
+
         if "CPU" in _arg.device:
             with cp.cuda.Device(device):
                 _arg = cp.asarray(_arg.numpy())
@@ -282,6 +295,8 @@ def _array_to_cupy(_arg, device=None):
 
 def _array_to_torch(_arg, device=None):
     """Convert array to torch."""
+    import torch
+
     if device is None:
         device = _get_device(_arg)
     xp = get_array_module(_arg)
@@ -291,9 +306,13 @@ def _array_to_torch(_arg, device=None):
         if torch.cuda.is_available():
             _arg = torch.from_dlpack(_arg)
         else:
+            import cupy as cp
+
             warnings.warn("data is on gpu, it will be moved to CPU.")
             _arg = torch.as_tensor(cp.asnumpy(_arg))
     elif "tensorflow" in xp.__name__:
+        import tensorflow as tf
+
         if "CPU" in _arg.device:
             _arg = torch.as_tensor(_arg.numpy(), device=device)
         else:
@@ -302,22 +321,28 @@ def _array_to_torch(_arg, device=None):
 
 
 def _array_to_tensorflow(_arg):
+    import tensorflow as tf
+
     xp = get_array_module(_arg)
     if xp.__name__ == "numpy":
         with tf.device("CPU"):
             _arg = tf.convert_to_tensor(_arg)
     elif xp.__name__ == "cupy":
-        if TF_CUDA_AVAILABLE:
+        if _tf_cuda_is_available():
             _arg = tf.experimental.dlpack.from_dlpack(_arg.toDlpack())
         else:
+            import cupy as cp
+
             warnings.warn("data is on gpu, it will be moved to CPU.")
             _arg = tf.convert_to_tensor(cp.asnumpy(_arg))
     elif xp.__name__ == "torch":
+        import torch
+
         if _arg.requires_grad:
             _arg = _arg.detach()
         if _arg.is_cpu:
             _arg = tf.convert_to_tensor(_arg)
-        elif TF_CUDA_AVAILABLE:
+        elif _tf_cuda_is_available():
             _arg = tf.experimental.dlpack.from_dlpack(
                 torch.utils.dlpack.to_dlpack(_arg)
             )
@@ -332,9 +357,9 @@ def _convert(_array_to_xp, args, kwargs=None):
         _arg = args[n]
         # All array are converted to the detected module
         # but numpy scalars are left as is.
-        if isinstance(_arg, ArrayTypes):
+        if is_array(_arg):
             args[n] = _array_to_xp(_arg)
-        elif isinstance(_arg, tuple | list) and isinstance(_arg[0], ArrayTypes):
+        elif isinstance(_arg, tuple | list) and is_array(_arg[0]):
             args[n], _ = _convert(_array_to_xp, _arg)
         elif isinstance(_arg, dict):
             _, args[n] = _convert(_array_to_xp, [], _arg)

--- a/src/mrinufft/operators/__init__.py
+++ b/src/mrinufft/operators/__init__.py
@@ -39,9 +39,21 @@ for v in FourierOperatorBase.interfaces.values():
     __all__.append(v[1].__name__)  # add the interface to the __all__ list
     globals()[v[1].__name__] = v[1]  # add the interface to the module namespace
 
-try:
-    from .autodiff import kspace_as_real, kspace_as_cpx, image_as_real, image_as_cpx
+# Autodiff helpers live in `.autodiff`, which imports torch + deepinv at module
+# scope. Expose them lazily so importing `operators` (e.g. via `get_operator`)
+# does not drag in those heavy deps; they load only on first access.
+from mrinufft._array_compat import AUTOGRAD_AVAILABLE, DEEPINV_AVAILABLE
 
-    __all__ += ["kspace_as_real", "kspace_as_cpx", "image_as_real", "image_as_cpx"]
-except ImportError:
-    pass
+_AUTODIFF_HELPERS = ("kspace_as_real", "kspace_as_cpx", "image_as_real", "image_as_cpx")
+
+if AUTOGRAD_AVAILABLE and DEEPINV_AVAILABLE:
+    __all__ += list(_AUTODIFF_HELPERS)
+
+
+def __getattr__(name):
+    """Lazily resolve the autodiff helpers (PEP 562)."""
+    if name in _AUTODIFF_HELPERS:
+        from . import autodiff
+
+        return getattr(autodiff, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/mrinufft/operators/interfaces/bart.py
+++ b/src/mrinufft/operators/interfaces/bart.py
@@ -14,7 +14,6 @@ from mrinufft._utils import proper_trajectory
 from mrinufft.operators.base import FourierOperatorCPU
 
 import numpy as np
-from mrinufft.io.cfl import traj2cfl, _writecfl, _readcfl
 
 # available if return code is 0
 try:
@@ -29,6 +28,12 @@ class RawBartNUFFT:
     """Wrapper around BART NUFFT CLI."""
 
     def __init__(self, samples, shape, extra_op_args=None, extra_adj_op_args=None):
+
+        from mrinufft.io.cfl import traj2cfl, _writecfl, _readcfl
+
+        self._writecfl = _writecfl
+        self._readcfl = _readcfl
+
         self.samples = samples  # To normalize and send to file
         self.shape = shape
         self.shape_str = ":".join([str(s) for s in shape])
@@ -56,7 +61,7 @@ class RawBartNUFFT:
     def op(self, coeffs_data, grid_data):
         """Forward Operator."""
         grid_data_ = grid_data.reshape(self.shape)
-        _writecfl(grid_data_, self._grid_file)
+        self._writecfl(grid_data_, self._grid_file)
         cmd = [
             "bart",
             "nufft",
@@ -77,7 +82,7 @@ class RawBartNUFFT:
             msg += f"stderr: {exc.stderr}"
             raise RuntimeError(msg) from exc
 
-        ksp_raw = _readcfl(self._ksp_file)
+        ksp_raw = self._readcfl(self._ksp_file)
         np.copyto(coeffs_data, ksp_raw)
         return coeffs_data
 
@@ -87,7 +92,7 @@ class RawBartNUFFT:
         # Run bart nufft with argument in subprocess
 
         coeffs_ = coeffs_data.reshape(len(self.samples))
-        _writecfl(coeffs_[None, ..., None, None, None], self._ksp_file)
+        self._writecfl(coeffs_[None, ..., None, None, None], self._ksp_file)
 
         cmd = [
             "bart",
@@ -110,7 +115,7 @@ class RawBartNUFFT:
             msg += f"stderr: {exc.stderr}"
             raise RuntimeError(msg) from exc
 
-        grid_raw = _readcfl(self._grid_file)
+        grid_raw = self._readcfl(self._grid_file)
         np.copyto(grid_data, grid_raw)
         return grid_data
 

--- a/src/mrinufft/operators/interfaces/nfft.py
+++ b/src/mrinufft/operators/interfaces/nfft.py
@@ -1,20 +1,19 @@
 """An implementation of the NUDFT using numpy."""
 
+import importlib.util
 import numpy as np
 
 from mrinufft.operators.base import FourierOperatorCPU
 
-PYNFFT_AVAILABLE = True
-try:
-    import pyNFFT3 as pynfft3
-except ImportError:
-    PYNFFT_AVAILABLE = False
+PYNFFT_AVAILABLE = importlib.util.find_spec("pyNFFT3") is not None
 
 
 class RawPyNFFT3:
     """Binding for the pyNFFT3 package."""
 
     def __init__(self, samples, shape):
+        import pyNFFT3 as pynfft3
+
         self.samples = samples
         self.shape = shape
         self.plan = pynfft3.NFFT(N=np.array(shape, dtype="int32"), M=len(samples))

--- a/src/mrinufft/operators/interfaces/sigpy.py
+++ b/src/mrinufft/operators/interfaces/sigpy.py
@@ -4,18 +4,12 @@ The SigPy NUFFT is fully implemented in Python.
 """
 
 import warnings
-
+from mrinufft._array_compat import _module_available
 import numpy as np
 from mrinufft._utils import proper_trajectory
 from mrinufft.operators.base import FourierOperatorCPU
 
-SIGPY_AVAILABLE = True
-try:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        import sigpy.fourier as sgf
-except ImportError:
-    SIGPY_AVAILABLE = False
+SIGPY_AVAILABLE = _module_available("sigpy")
 
 
 class RawSigpyNUFFT:
@@ -64,6 +58,8 @@ class RawSigpyNUFFT:
 
     def op(self, coeffs_data, grid_data):
         """Forward Operator."""
+        import sigpy.fourier as sgf
+
         grid_data_ = grid_data.reshape(self.n_trans, *self.shape)
         ret = sgf.nufft(
             grid_data_,
@@ -77,6 +73,8 @@ class RawSigpyNUFFT:
 
     def adj_op(self, coeffs_data, grid_data):
         """Adjoint Operator."""
+        import sigpy.fourier as sgf
+
         coeffs_data_ = coeffs_data.reshape(self.n_trans, len(self.samples))
         ret = sgf.nufft_adjoint(
             coeffs_data_,

--- a/src/mrinufft/operators/interfaces/torchkbnufft.py
+++ b/src/mrinufft/operators/interfaces/torchkbnufft.py
@@ -5,7 +5,7 @@ import numpy as np
 from mrinufft.operators.base import FourierOperatorBase
 from mrinufft._utils import proper_trajectory
 from mrinufft._array_compat import (
-    ArrayTypes,
+    is_array,
     is_cuda_tensor,
     with_torch,
     _array_to_torch,
@@ -125,7 +125,7 @@ class MRITorchKbNufft(FourierOperatorBase):
             self._smaps = None
             return
 
-        if not isinstance(new_smaps, ArrayTypes):
+        if not is_array(new_smaps):
             raise TypeError("Smaps should be an array-like object.")
         new_smaps = _array_to_torch(new_smaps)
 

--- a/src/mrinufft/operators/interfaces/torchkbnufft.py
+++ b/src/mrinufft/operators/interfaces/torchkbnufft.py
@@ -9,14 +9,11 @@ from mrinufft._array_compat import (
     is_cuda_tensor,
     with_torch,
     _array_to_torch,
+    TORCH_AVAILABLE,
+    _module_available,
 )
 
-TORCH_AVAILABLE = True
-try:
-    import torchkbnufft as tkbn
-    import torch
-except ImportError:
-    TORCH_AVAILABLE = False
+TORCHKBNUFFT_AVAILABLE = _module_available("torchkbnufft") and TORCH_AVAILABLE
 
 
 class MRITorchKbNufft(FourierOperatorBase):
@@ -60,7 +57,7 @@ class MRITorchKbNufft(FourierOperatorBase):
 
     """
 
-    available = TORCH_AVAILABLE
+    available = TORCHKBNUFFT_AVAILABLE
     autograd_available = False
 
     def __init__(
@@ -78,6 +75,8 @@ class MRITorchKbNufft(FourierOperatorBase):
         **kwargs,
     ):
         super().__init__()
+        import torch
+        import torchkbnufft as tkbn
 
         if use_gpu:
             self.device = "cuda"
@@ -221,10 +220,10 @@ class MRITorchKbNufft(FourierOperatorBase):
         cls,
         kspace_loc,
         volume_shape,
-        max_iter=10,
-        osf=2,
-        normalize=True,
-        use_gpu=False,
+        max_iter: int = 10,
+        osf: float = 2,
+        normalize: bool = True,
+        use_gpu: bool = False,
         **kwargs,
     ):
         """Compute the density compensation weights for a given set of kspace locations.
@@ -245,7 +244,10 @@ class MRITorchKbNufft(FourierOperatorBase):
         use_gpu: bool, default False
             Whether to use the GPU
         """
-        volume_shape = (np.array(volume_shape) * osf).astype(int)
+        import torchkbnufft as tkbn
+        import torch
+
+        volume_shape = tuple((np.array(volume_shape) * osf).astype(int))
         grid_op = MRITorchKbNufft(
             samples=kspace_loc,
             shape=volume_shape,
@@ -254,7 +256,7 @@ class MRITorchKbNufft(FourierOperatorBase):
             **kwargs,
         )
         density_comp = tkbn.calc_density_compensation_function(
-            ktraj=kspace_loc, im_size=volume_shape, max_iter=max_iter
+            ktraj=kspace_loc, im_size=volume_shape, num_iterations=max_iter
         )
         if normalize:
             spike = torch.zeros(volume_shape, dtype=torch.float32).to(grid_op.device)

--- a/src/mrinufft/operators/subspace.py
+++ b/src/mrinufft/operators/subspace.py
@@ -3,7 +3,6 @@
 from mrinufft._array_compat import (
     _get_device,
     _to_interface,
-    ARRAY_LIBS,
     get_array_module,
 )
 
@@ -163,23 +162,3 @@ class MRISubspace(FourierOperatorBase):
     def __getattr__(self, name):
         """Delegate attribute access to the underlying fourier operator."""
         return getattr(self._fourier_op, name)
-
-
-def _get_arraylib_from_operator(
-    fourier_op, use_gpu
-):  # maybe that is usefull for MRIFourierCorrected constructor?
-    LUT = {
-        "MRIBartNUFFT": ("numpy", "numpy"),
-        "MRICufiNUFFT": ("cupy", "cupy"),
-        "MRIfinufft": ("numpy", "numpy"),
-        "MRIDUCC0": ("numpy", "numpy"),
-        "MRIGpuNUFFT": ("cupy", "cupy"),
-        "MRInfft": ("numpy", "numpy"),
-        "MRIPynufft": ("numpy", "numpy"),
-        "MRISigpyNUFFT": ("numpy", "cupy"),
-        "MRITensorflowNUFFT": ("tensorflow", "tensorflow"),
-        "MRITorchKbNufft": ("torch", "torch"),
-        "TorchKbNUFFTcpu": ("torch", "torch"),
-        "TorchKbNUFFTgpu": ("torch", "torch"),
-    }
-    return ARRAY_LIBS[LUT[fourier_op.__class__.__name__][use_gpu]][0]


### PR DESCRIPTION
- Closes #7 

`from mrinufft import get_operator` is now 10x faster! 

Changes proposed in this pull request:

- Use PEP562 for the main `__init__.py` , only load submodules. That way, a `get_operator` import does not need to load display functions. 
- Rework `_array_compat.py` to be slimer and more efficient
- Use `importlib.util.find_spec` to check for module availability, rather than the `try/except` setup. 

Interestingly the slowest nuffts where also the slowest to import, as their usage is unlikey (`sigpy`, `bart`, `torckbnufft`) the import is deferred to their instantiation. 



Before (with most of the backends installed)
<img width="3188" height="2004" alt="image" src="https://github.com/user-attachments/assets/4af5de01-0654-4306-ab08-deab70e55092" />
 

After: 

<img width="3188" height="2004" alt="image" src="https://github.com/user-attachments/assets/4b57e8a4-8556-4064-9768-563967556873" />

to reproduce: 

```
uv run python -X importtime -c "from mrinufft import get_operator" 2> import.log
uvx tuna import.log 
```

